### PR TITLE
fix screenshare button when cancel is clicked

### DIFF
--- a/template/bridge/rtc/web/RtcEngine.ts
+++ b/template/bridge/rtc/web/RtcEngine.ts
@@ -114,7 +114,6 @@ export default class RtcEngine {
 
 
     async joinChannel(token: string, channelName: string, optionalInfo: string, optionalUid: number): Promise<void> {
-        let self = this;
         let join = new Promise((resolve, reject) => {
             this.client.on('stream-added', (evt) => {
                 this.inScreenshare ?
@@ -286,14 +285,26 @@ export default class RtcEngine {
                 });
             }));
             await init;
-
-            let enable = new Promise(((resolve, reject) => {
-                this.streams.set(1, AgoraRTC.createStream(this.streamSpecScreenshare));
-                (this.streams.get(1) as AgoraRTC.Stream).init(() => {
-                    resolve();
-                }, reject);
-            }));
-            await enable;
+            try {
+                let enable = new Promise(((resolve, reject) => {
+                    try {
+                        console.log('[screenshare]: creating stream');
+                        this.streams.set(1, AgoraRTC.createStream(this.streamSpecScreenshare));
+                    }
+                    catch (e){
+                        console.error("[screenshare]: Couldn't createStream", e);
+                    }
+                    console.log('[screenshare]: Initalizing stream');
+                    (this.streams.get(1) as AgoraRTC.Stream).init(() => {
+                        console.log('[screenshare]: initalized stream');
+                        resolve();
+                    }, reject);
+                }));
+                await enable;
+            } catch (e){
+                console.log('[screenshare]: Error during intialization');
+                throw e;
+            }
 
             let join = new Promise((resolve, reject) => {
                 if (encryption && encryption.screenKey && encryption.mode) {

--- a/template/src/subComponents/ScreenshareButton.tsx
+++ b/template/src/subComponents/ScreenshareButton.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useContext, useEffect} from 'react';
 import {Image, TouchableOpacity, StyleSheet} from 'react-native';
 import icons from '../assets/icons';
 import RtcContext from '../../agora-rn-uikit/src/RtcContext';
@@ -26,9 +26,12 @@ const ScreenshareButton = (props: ScreenSharingProps) => {
     encryption,
   } = useContext(PropsContext).rtcProps;
 
-  rtc.RtcEngine.addListener('ScreenshareStopped', () => {
-    setScreenshareActive(false);
-  });
+  useEffect(() => {
+    rtc.RtcEngine.addListener('ScreenshareStopped', () => {
+      setScreenshareActive(false);
+    });
+  }, []);
+
   return (
     <TouchableOpacity
       style={
@@ -36,17 +39,21 @@ const ScreenshareButton = (props: ScreenSharingProps) => {
           ? style.greenLocalButton
           : [style.localButton, {borderColor: primaryColor}]
       }
-      onPress={() => {
-        setScreenshareActive(true);
-        rtc.RtcEngine.startScreenshare(
-          screenShareToken,
-          channel,
-          null,
-          screenShareUid,
-          appId,
-          rtc.RtcEngine,
-          encryption,
-        );
+      onPress={async () => {
+        try {
+          await rtc.RtcEngine.startScreenshare(
+            screenShareToken,
+            channel,
+            null,
+            screenShareUid,
+            appId,
+            rtc.RtcEngine,
+            encryption,
+          );
+          setScreenshareActive(true);
+        } catch (e) {
+          console.error("can't start the screen share", e);
+        }
       }}>
       <Image
         source={{


### PR DESCRIPTION
Changes the behaviour of the green highlight too occur after the screenshare has started.

Fixes the Rtc bridge to throw an error when screenshare is cancelled.
