### PR TITLE
Private notification toast

### DIFF
--- a/template/src/components/ChatContext.ts
+++ b/template/src/components/ChatContext.ts
@@ -11,6 +11,8 @@
 */
 import RtmEngine from 'agora-react-native-rtm';
 import {createContext} from 'react';
+import {mType} from './RTMConfigure';
+import {rtmEventsInterface} from './RTMEvents';
 
 export interface channelMessage {
   isLocal: boolean;
@@ -25,6 +27,20 @@ export interface messageStoreInterface {
   msg: string;
 }
 
+export interface messageEventInterface extends messageStoreInterface {
+  type: mType;
+  source: mSourceType;
+}
+
+export enum mSourceType {
+  Core = 'core',
+}
+
+export enum mChannelType {
+  Private = 'private',
+  Public = 'public',
+}
+
 interface chatContext {
   messageStore: messageStoreInterface | any;
   privateMessageStore: any;
@@ -35,6 +51,7 @@ interface chatContext {
   engine: RtmEngine;
   localUid: string;
   userList: any;
+  events: rtmEventsInterface;
   // peersRTM: Array<string>;
 }
 
@@ -48,6 +65,6 @@ export enum controlMessageEnum {
   cloudRecordingUnactive = '7',
 }
 
-const ChatContext = createContext((null as unknown) as chatContext);
+const ChatContext = createContext(null as unknown as chatContext);
 
 export default ChatContext;

--- a/template/src/components/ChatContext.ts
+++ b/template/src/components/ChatContext.ts
@@ -11,7 +11,6 @@
 */
 import RtmEngine from 'agora-react-native-rtm';
 import {createContext} from 'react';
-import {mType} from './RTMConfigure';
 import {rtmEventsInterface} from './RTMEvents';
 
 export interface channelMessage {
@@ -28,17 +27,22 @@ export interface messageStoreInterface {
 }
 
 export interface messageEventInterface extends messageStoreInterface {
-  type: mType;
-  source: mSourceType;
+  type: messageActionType;
+  source: messageSourceType;
 }
 
-export enum mSourceType {
+export enum messageSourceType {
   Core = 'core',
 }
 
-export enum mChannelType {
+export enum messageChannelType {
   Private = 'private',
   Public = 'public',
+}
+
+export enum messageActionType {
+  Control = '0',
+  Normal = '1',
 }
 
 interface chatContext {

--- a/template/src/components/RTMConfigure.tsx
+++ b/template/src/components/RTMConfigure.tsx
@@ -14,9 +14,10 @@ import RtmEngine from 'agora-react-native-rtm';
 import PropsContext from '../../agora-rn-uikit/src/PropsContext';
 import ChatContext, {controlMessageEnum} from './ChatContext';
 import RtcContext from '../../agora-rn-uikit/src/RtcContext';
-import {messageStoreInterface} from './ChatContext';
+import {messageStoreInterface, mChannelType, mSourceType} from './ChatContext';
 import {Platform} from 'react-native';
 import {backOff} from 'exponential-backoff';
+import events from './RTMEvents';
 
 export enum mType {
   Control = '0',
@@ -28,6 +29,27 @@ export enum UserType {
   ScreenShare,
 }
 
+const adjustUID = (number: number) => {
+  if (number < 0) {
+    number = 0xffffffff + number + 1;
+  }
+  return number;
+};
+
+const stringifyPayload = (source: mSourceType, type: mType, msg: string) => {
+  return JSON.stringify({
+    source,
+    type,
+    msg,
+  });
+};
+
+const parsePayload = (data: string) => {
+  return JSON.parse(data);
+};
+
+const timeNow = () => new Date().getTime();
+
 const RtmConfigure = (props: any) => {
   const {setRecordingActive, callActive, name} = props;
   const {rtcProps} = useContext(PropsContext);
@@ -35,9 +57,10 @@ const RtmConfigure = (props: any) => {
   const [messageStore, setMessageStore] = useState<messageStoreInterface[]>([]);
   const [privateMessageStore, setPrivateMessageStore] = useState({});
   const [login, setLogin] = useState<boolean>(false);
-  const [userList, setUserList] = useState({});
+  const [userList, setUserList] = useState<{[key: string]: any}>({});
   let engine = useRef<RtmEngine>(null!);
   let localUid = useRef<string>('');
+
   const addMessageToStore = (uid: string, text: string, ts: string) => {
     setMessageStore((m: messageStoreInterface[]) => {
       return [...m, {ts: ts, uid: uid, msg: text}];
@@ -63,14 +86,13 @@ const RtmConfigure = (props: any) => {
           });
       return {...newState};
     });
-    // console.log(privateMessageStore);
   };
 
   const init = async () => {
     engine.current = new RtmEngine();
     rtcProps.uid
       ? (localUid.current = rtcProps.uid + '')
-      : (localUid.current = '' + new Date().getTime());
+      : (localUid.current = '' + timeNow());
     engine.current.on('error', (evt: any) => {
       // console.log(evt);
     });
@@ -98,8 +120,6 @@ const RtmConfigure = (props: any) => {
         try {
           const attr = await backoffAttributes;
           console.log('[user attributes]:', {attr});
-          // let arr = new Int32Array(1);
-          // arr[0] = parseInt(data.uid);
           setUserList((prevState) => {
             return {
               ...prevState,
@@ -123,94 +143,136 @@ const RtmConfigure = (props: any) => {
     engine.current.on('channelMemberLeft', (data: any) => {
       console.log('user left', data);
       // Chat of left user becomes undefined. So don't cleanup
-      //
-      // let arr = new Int32Array(1);
-      // arr[0] = parseInt(data.uid);
-      // setUserList((prevState) => {
-      //   const uid: number = Platform.OS === 'android' ? arr[0] : data.uid;
-      //   const screenuid: number = prevState[uid].screenUid;
-      //   const {[uid]: _user, [screenuid]: _screen, ...newState} = prevState;
-      //   return newState;
-      // });
     });
     engine.current.on('messageReceived', (evt: any) => {
-      let {text} = evt;
-      // console.log('messageReceived: ', evt);
-      if (text[0] === mType.Control) {
-        console.log('Control: ', text);
-        if (text.slice(1) === controlMessageEnum.muteVideo) {
-          // console.log('dispatch', dispatch);
-          dispatch({
-            type: 'LocalMuteVideo',
-            value: [true],
+      const {peerId, ts, text} = evt;
+      const textObj = parsePayload(text);
+      const {type, msg} = textObj;
+
+      let arr = new Int32Array(1);
+      arr[0] = parseInt(peerId);
+
+      const inHours = new Date(ts).getHours();
+      const timestamp = isNaN(inHours) ? timeNow() : inHours;
+      const userUID = Platform.OS === 'android' ? arr[0] : peerId;
+
+      if (type === mType.Control) {
+        try {
+          switch (msg) {
+            case controlMessageEnum.muteVideo:
+              dispatch({
+                type: 'LocalMuteVideo',
+                value: [true],
+              });
+              break;
+            case controlMessageEnum.muteAudio:
+              dispatch({
+                type: 'LocalMuteAudio',
+                value: [true],
+              });
+              break;
+            case controlMessageEnum.kickUser:
+              dispatch({
+                type: 'EndCall',
+                value: [],
+              });
+              break;
+            default:
+              break;
+          }
+        } catch (e) {
+          events.emit(mChannelType.Private, null, {
+            msg: `Error while dispatching ${mChannelType.Private} control message`,
+            cause: e,
           });
-        } else if (text.slice(1) === controlMessageEnum.muteAudio) {
-          dispatch({
-            type: 'LocalMuteAudio',
-            value: [true],
-          });
-        } else if (text.slice(1) === controlMessageEnum.kickUser) {
-          dispatch({
-            type: 'EndCall',
-            value: [],
-          });
+          return;
         }
-      } else if (text[0] === mType.Normal) {
-        let arr = new Int32Array(1);
-        arr[0] = parseInt(evt.peerId);
-        // console.log(evt);
-        let hours = new Date(evt.ts).getHours;
-        if (isNaN(hours)) {
-          evt.ts = new Date().getTime();
+      } else if (type === mType.Normal) {
+        try {
+          addMessageToPrivateStore(
+            userUID,
+            `${type}${msg}`,
+            timestamp.toString(),
+            false,
+          );
+        } catch (e) {
+          events.emit(mChannelType.Private, null, {
+            msg: `Error while adding ${mChannelType.Private} message to store`,
+            cause: e,
+          });
+          return;
         }
-        addMessageToPrivateStore(
-          Platform.OS === 'android' ? arr[0] : evt.peerId,
-          evt.text,
-          evt.ts,
-          false,
-        );
       }
+      events.emit(mChannelType.Private, {
+        uid: userUID,
+        ts: timestamp.toString(),
+        ...textObj,
+      });
     });
+
     engine.current.on('channelMessageReceived', (evt) => {
-      let {uid, channelId, text, ts} = evt;
-      // if (uid < 0) {
-      //   uid = uid + parseInt(0xFFFFFFFF) + 1;
-      // }
+      const {uid, channelId, text, ts} = evt;
+      const textObj = parsePayload(text);
+      const {type, msg} = textObj;
+
       let arr = new Int32Array(1);
       arr[0] = parseInt(uid);
-      Platform.OS ? (uid = arr[0]) : {};
-      // console.log(evt);
-      if (ts === 0) {
-        ts = new Date().getTime();
-      }
+
+      const userUID = Platform.OS ? arr[0] : uid;
+      console.log('userId', userUID);
+      const timestamp = ts === 0 ? timeNow() : ts;
+
       if (channelId === rtcProps.channel) {
-        if (text[0] === mType.Control) {
-          console.log('Control: ', text);
-          if (text.slice(1) === controlMessageEnum.muteVideo) {
-            // console.log('dispatch', dispatch);
-            dispatch({
-              type: 'LocalMuteVideo',
-              value: [true],
+        if (type === mType.Control) {
+          try {
+            switch (msg) {
+              case controlMessageEnum.muteVideo:
+                dispatch({
+                  type: 'LocalMuteVideo',
+                  value: [true],
+                });
+                break;
+              case controlMessageEnum.muteAudio:
+                dispatch({
+                  type: 'LocalMuteAudio',
+                  value: [true],
+                });
+                break;
+              case controlMessageEnum.cloudRecordingActive:
+                setRecordingActive(true);
+                break;
+              case controlMessageEnum.cloudRecordingUnactive:
+                setRecordingActive(false);
+                break;
+              default:
+                break;
+            }
+          } catch (e) {
+            events.emit(mChannelType.Public, null, {
+              msg: `Error while dispatching ${mChannelType.Public} control message`,
+              cause: e,
             });
-          } else if (text.slice(1) === controlMessageEnum.muteAudio) {
-            dispatch({
-              type: 'LocalMuteAudio',
-              value: [true],
-            });
-          } else if (
-            text.slice(1) === controlMessageEnum.cloudRecordingActive
-          ) {
-            setRecordingActive(true);
-          } else if (
-            text.slice(1) === controlMessageEnum.cloudRecordingUnactive
-          ) {
-            setRecordingActive(false);
+            return;
           }
-        } else if (text[0] === mType.Normal) {
-          addMessageToStore(uid, text, ts);
+        } else if (type === mType.Normal) {
+          try {
+            addMessageToStore(userUID, `${type}${msg}`, timestamp);
+          } catch (e) {
+            events.emit(mChannelType.Public, null, {
+              msg: `Error while adding ${mChannelType.Public}  message to store`,
+              cause: e,
+            });
+            return;
+          }
         }
       }
+      events.emit(mChannelType.Public, {
+        uid: userUID,
+        ts: timestamp,
+        ...textObj,
+      });
     });
+
     engine.current.createClient(rtcProps.appId);
     await engine.current.login({
       uid: localUid.current,
@@ -249,8 +311,6 @@ const RtmConfigure = (props: any) => {
           try {
             const attr = await backoffAttributes;
             console.log('[user attributes]:', {attr});
-            // let arr = new Int32Array(1);
-            // arr[0] = parseInt(data.uid);
             setUserList((prevState) => {
               return {
                 ...prevState,
@@ -275,52 +335,49 @@ const RtmConfigure = (props: any) => {
   };
 
   const sendMessage = async (msg: string) => {
-    if (msg !== '') {
-      await (engine.current as RtmEngine).sendMessageByChannelId(
-        rtcProps.channel,
-        mType.Normal + msg,
-      );
-    }
-    let ts = new Date().getTime();
-    if (msg !== '') {
-      addMessageToStore(localUid.current, mType.Normal + msg, ts);
-    }
-  };
-  const sendMessageToUid = async (msg: string, uid: number) => {
-    let adjustedUID = uid;
-    if (adjustedUID < 0) {
-      adjustedUID = uid + parseInt(0xffffffff) + 1;
-    }
-    let ts = new Date().getTime();
-    if (msg !== '') {
-      await (engine.current as RtmEngine).sendMessageToPeer({
-        peerId: adjustedUID.toString(),
-        offline: false,
-        text: mType.Normal + '' + msg,
-      });
-    }
-    // console.log(ts);
-    if (msg !== '') {
-      addMessageToPrivateStore(uid, mType.Normal + msg, ts, true);
-    }
-  };
-  const sendControlMessage = async (msg: string) => {
+    if (msg.trim() === '') return;
+    const text = stringifyPayload(mSourceType.Core, mType.Normal, msg);
     await (engine.current as RtmEngine).sendMessageByChannelId(
       rtcProps.channel,
-      mType.Control + msg,
+      text,
     );
+    addMessageToStore(localUid.current, mType.Normal + msg, timeNow());
   };
-  const sendControlMessageToUid = async (msg: string, uid: number) => {
+  const sendMessageToUid = async (msg: string, uid: number) => {
+    if (msg.trim() === '') return;
     let adjustedUID = uid;
     if (adjustedUID < 0) {
-      adjustedUID = uid + parseInt(0xffffffff) + 1;
+      adjustedUID = adjustUID(uid);
     }
+    const text = stringifyPayload(mSourceType.Core, mType.Normal, msg);
     await (engine.current as RtmEngine).sendMessageToPeer({
       peerId: adjustedUID.toString(),
       offline: false,
-      text: mType.Control + '' + msg,
+      text,
+    });
+    addMessageToPrivateStore(uid, mType.Normal + msg, timeNow(), true);
+  };
+
+  const sendControlMessage = async (msg: string) => {
+    const text = stringifyPayload(mSourceType.Core, mType.Control, msg);
+    await (engine.current as RtmEngine).sendMessageByChannelId(
+      rtcProps.channel,
+      text,
+    );
+  };
+
+  const sendControlMessageToUid = async (msg: string, uid: number) => {
+    if (uid < 0) {
+      uid = adjustUID(uid);
+    }
+    const text = stringifyPayload(mSourceType.Core, mType.Control, msg);
+    await (engine.current as RtmEngine).sendMessageToPeer({
+      peerId: uid.toString(),
+      offline: false,
+      text,
     });
   };
+
   const end = async () => {
     callActive
       ? (await (engine.current as RtmEngine).logout(),
@@ -350,6 +407,7 @@ const RtmConfigure = (props: any) => {
         engine: engine.current,
         localUid: localUid.current,
         userList: userList,
+        events,
       }}>
       {login ? props.children : <></>}
     </ChatContext.Provider>

--- a/template/src/components/RTMEvents.tsx
+++ b/template/src/components/RTMEvents.tsx
@@ -1,0 +1,80 @@
+/*
+********************************************
+ Copyright © 2021 Agora Lab, Inc., all rights reserved.
+ AppBuilder and all associated components, source code, APIs, services, and documentation 
+ (the “Materials”) are owned by Agora Lab, Inc. and its licensors. The Materials may not be 
+ accessed, used, modified, or distributed for any purpose without a license from Agora Lab, Inc.  
+ Use without a license or in violation of any license terms and conditions (including use for 
+ any purpose competitive to Agora Lab, Inc.’s business) is strictly prohibited. For more 
+ information visit https://appbuilder.agora.io. 
+*********************************************
+*/
+
+import {mChannelType, messageEventInterface} from './ChatContext';
+
+const RTM_ERROR_TEMPLATE = 'RTMError:';
+
+type eventsMapInterface = {
+  [key in mChannelType]: Record<string, any>;
+};
+
+type errorObjectInterface = {
+  msg: string;
+  cause: any;
+};
+
+type eventKeyType = keyof eventsMapInterface;
+
+const eventsMap: eventsMapInterface = {
+  [mChannelType.Private]: new Map<string, any>(),
+  [mChannelType.Public]: new Map<string, any>(),
+};
+
+export interface rtmEventsInterface {
+  on: (mChannel: mChannelType, evtName: string, callback: any) => void;
+  emit: (
+    mChannel: mChannelType,
+    data: messageEventInterface | any | null,
+    error?: errorObjectInterface | null | undefined,
+  ) => void;
+  off: (mChannel: mChannelType, evtName: string) => void;
+  destroyAll: () => void;
+}
+
+const events: rtmEventsInterface = {
+  on: (mChannel: mChannelType, evtName: string, callback: any) => {
+    eventsMap[mChannel].set(evtName, callback);
+  },
+  emit: (
+    mChannel: mChannelType,
+    data: messageEventInterface | any | null,
+    error: errorObjectInterface | null | undefined,
+  ) => {
+    // Handle error, if error found return error in callback
+    if (error) {
+      let err = new Error(`${RTM_ERROR_TEMPLATE}: ${error.msg}`);
+      err.stack += '\nCaused by: ' + error.cause;
+
+      for (const [key] of eventsMap[mChannel].entries()) {
+        eventsMap[mChannel].get(`${key}`)(null, err);
+      }
+      return;
+    }
+    // Handle success, return data in callback
+    for (const [key] of eventsMap[mChannel].entries()) {
+      eventsMap[mChannel].get(`${key}`)(data, null);
+    }
+  },
+  off: (mChannel: mChannelType, evtName: string) => {
+    eventsMap[mChannel].delete(evtName);
+  },
+  destroyAll: () => {
+    for (const key of Object.keys(eventsMap) as Array<eventKeyType>) {
+      eventsMap[key].clear();
+    }
+  },
+};
+
+Object.freeze(events);
+
+export default events;

--- a/template/src/components/RTMEvents.tsx
+++ b/template/src/components/RTMEvents.tsx
@@ -10,12 +10,12 @@
 *********************************************
 */
 
-import {mChannelType, messageEventInterface} from './ChatContext';
+import {messageChannelType, messageEventInterface} from './ChatContext';
 
 const RTM_ERROR_TEMPLATE = 'RTMError:';
 
 type eventsMapInterface = {
-  [key in mChannelType]: Record<string, any>;
+  [key in messageChannelType]: Record<string, any>;
 };
 
 type errorObjectInterface = {
@@ -26,27 +26,31 @@ type errorObjectInterface = {
 type eventKeyType = keyof eventsMapInterface;
 
 const eventsMap: eventsMapInterface = {
-  [mChannelType.Private]: new Map<string, any>(),
-  [mChannelType.Public]: new Map<string, any>(),
+  [messageChannelType.Private]: new Map<string, any>(),
+  [messageChannelType.Public]: new Map<string, any>(),
 };
 
 export interface rtmEventsInterface {
-  on: (mChannel: mChannelType, evtName: string, callback: any) => void;
+  on: (
+    messageChannel: messageChannelType,
+    evtName: string,
+    callback: any,
+  ) => void;
   emit: (
-    mChannel: mChannelType,
+    messageChannel: messageChannelType,
     data: messageEventInterface | any | null,
     error?: errorObjectInterface | null | undefined,
   ) => void;
-  off: (mChannel: mChannelType, evtName: string) => void;
+  off: (messageChannel: messageChannelType, evtName: string) => void;
   destroyAll: () => void;
 }
 
 const events: rtmEventsInterface = {
-  on: (mChannel: mChannelType, evtName: string, callback: any) => {
-    eventsMap[mChannel].set(evtName, callback);
+  on: (messageChannel: messageChannelType, evtName: string, callback: any) => {
+    eventsMap[messageChannel].set(evtName, callback);
   },
   emit: (
-    mChannel: mChannelType,
+    messageChannel: messageChannelType,
     data: messageEventInterface | any | null,
     error: errorObjectInterface | null | undefined,
   ) => {
@@ -55,18 +59,18 @@ const events: rtmEventsInterface = {
       let err = new Error(`${RTM_ERROR_TEMPLATE}: ${error.msg}`);
       err.stack += '\nCaused by: ' + error.cause;
 
-      for (const [key] of eventsMap[mChannel].entries()) {
-        eventsMap[mChannel].get(`${key}`)(null, err);
+      for (const [key] of eventsMap[messageChannel].entries()) {
+        eventsMap[messageChannel].get(`${key}`)(null, err);
       }
       return;
     }
     // Handle success, return data in callback
-    for (const [key] of eventsMap[mChannel].entries()) {
-      eventsMap[mChannel].get(`${key}`)(data, null);
+    for (const [key] of eventsMap[messageChannel].entries()) {
+      eventsMap[messageChannel].get(`${key}`)(data, null);
     }
   },
-  off: (mChannel: mChannelType, evtName: string) => {
-    eventsMap[mChannel].delete(evtName);
+  off: (messageChannel: messageChannelType, evtName: string) => {
+    eventsMap[messageChannel].delete(evtName);
   },
   destroyAll: () => {
     for (const key of Object.keys(eventsMap) as Array<eventKeyType>) {

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -30,7 +30,7 @@ import {gql, useQuery} from '@apollo/client';
 // import Watermark from '../subComponents/Watermark';
 import StorageContext from '../components/StorageContext';
 import Logo from '../subComponents/Logo';
-import ChatContext from '../components/ChatContext';
+import ChatContext, {mChannelType} from '../components/ChatContext';
 import {SidePanelType} from '../subComponents/SidePanelEnum';
 import {videoView} from '../../theme.json';
 import Layout from '../subComponents/LayoutEnum';
@@ -65,7 +65,7 @@ const useChatNotification = (
 };
 
 const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
-  const {messageStore, privateMessageStore, userList, localUid} =
+  const {messageStore, privateMessageStore, userList, localUid, events} =
     useContext(ChatContext);
   const [
     lastCheckedPublicState,
@@ -74,6 +74,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
     setLastCheckedPrivateState,
     setPrivateMessageLastSeen,
   ] = useChatNotification(messageStore, privateMessageStore, chatDisplayed);
+
   const pendingPublicNotification =
     messageStore.length - lastCheckedPublicState;
   const privateMessageCountMap = Object.keys(privateMessageStore).reduce(
@@ -98,41 +99,43 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
   );
   const pendingPrivateNotification = totalPrivateMessage - totalPrivateLastSeen;
 
-  // const oldMessageStore = useRef<messageStoreInterface[]>([]);
-  // useEffect(() => {
-  //   if (messageStore.length > oldMessageStore.current.length && messageStore[messageStore.length - 1].uid !== localUid) {
-  //     Toast.show({
-  //       text1: messageStore[messageStore.length - 1]?.msg.length > 50 ? messageStore[messageStore.length - 1]?.msg.slice(1, 50) + '...' : messageStore[messageStore.length - 1]?.msg.slice(1),
-  //       text2: userList[messageStore[messageStore.length - 1]?.uid] ? userList[messageStore[messageStore.length - 1]?.uid].name : 'User',
-  //       visibilityTime: 1000,
-  //       onPress: () => setSidePanel(SidePanelType.Chat),
-  //     });
-  //     oldMessageStore.current = messageStore;
-  //   }
-  // }, [messageStore, userList]);
-
-  useEffect(() => {
-    if (
-      messageStore.length !== 0 &&
-      messageStore[messageStore.length - 1]?.uid !== localUid
-    ) {
+  React.useEffect(() => {
+    const showMessageNotification = (data: any) => {
+      const {uid, msg} = data;
       Toast.show({
-        text1:
-          messageStore[messageStore.length - 1]?.msg.length > 50
-            ? messageStore[messageStore.length - 1]?.msg.slice(1, 50) + '...'
-            : messageStore[messageStore.length - 1]?.msg.slice(1),
-        text2: userList[messageStore[messageStore.length - 1]?.uid]
-          ? 'From: ' + userList[messageStore[messageStore.length - 1]?.uid].name
-          : '',
+        type: 'success',
+        text1: msg.length > 50 ? msg.slice(0, 50) + '...' : msg,
+        text2: userList[uid]?.name ? 'From: ' + userList[uid]?.name : '',
         visibilityTime: 1000,
         onPress: () => {
           setSidePanel(SidePanelType.Chat);
           setLastCheckedPublicState(messageStore.length);
         },
       });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messageStore]);
+    };
+    events.on(
+      mChannelType.Public,
+      'onPublicMessageReceived',
+      (data: any, error: any) => {
+        if (!data) return;
+        showMessageNotification(data);
+      },
+    );
+    events.on(
+      mChannelType.Private,
+      'onPrivateMessageReceived',
+      (data: any, error: any) => {
+        if (!data) return;
+        if (data.uid === localUid) return;
+        showMessageNotification(data);
+      },
+    );
+    return () => {
+      // Cleanup the listeners
+      events.off(mChannelType.Public, 'onPublicMessageReceived');
+      events.off(mChannelType.Private, 'onPrivateMessageReceived');
+    };
+  }, [userList, messageStore]);
 
   return children({
     pendingPublicNotification,

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -30,7 +30,7 @@ import {gql, useQuery} from '@apollo/client';
 // import Watermark from '../subComponents/Watermark';
 import StorageContext from '../components/StorageContext';
 import Logo from '../subComponents/Logo';
-import ChatContext, {mChannelType} from '../components/ChatContext';
+import ChatContext, {messageChannelType} from '../components/ChatContext';
 import {SidePanelType} from '../subComponents/SidePanelEnum';
 import {videoView} from '../../theme.json';
 import Layout from '../subComponents/LayoutEnum';
@@ -114,7 +114,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
       });
     };
     events.on(
-      mChannelType.Public,
+      messageChannelType.Public,
       'onPublicMessageReceived',
       (data: any, error: any) => {
         if (!data) return;
@@ -122,7 +122,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
       },
     );
     events.on(
-      mChannelType.Private,
+      messageChannelType.Private,
       'onPrivateMessageReceived',
       (data: any, error: any) => {
         if (!data) return;
@@ -132,8 +132,8 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
     );
     return () => {
       // Cleanup the listeners
-      events.off(mChannelType.Public, 'onPublicMessageReceived');
-      events.off(mChannelType.Private, 'onPrivateMessageReceived');
+      events.off(messageChannelType.Public, 'onPublicMessageReceived');
+      events.off(messageChannelType.Private, 'onPrivateMessageReceived');
     };
   }, [userList, messageStore]);
 


### PR DESCRIPTION
# Related Issue
- Generate toast notifications for private messages
- Clickup Issue: https://app.clickup.com/t/51hvqy

# Proposed changes/Fix
- Expose an API to subscribe, emit, destroy the listeners when a private or public message is received.
- Export this API in RTM(chatContext) provider, so that all the descendants of this component have access to this API.
- In Videocall component subscribe to private or public message events and register the callback to perform necessary actions.
- Add additional metadata when text is being sent over transport layer.

# Additional Info 
- RTMConfigure.tsx had lot of changes and the message passing through the transport layer now has changed and contains additional information, source and type of the message being sent.

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

Tested on devices: Desktop(electron) and Web

# Dependent PRs 
- NA


# Screenshots
Group and private notification demo on electron built app

[electron-notification-video.zip](https://github.com/AgoraIO-Community/app-builder-core/files/7388843/electron-notification-video.zip)
