### PR TITLE
Fix cramped UI when screen size is less or text is enlarged

### DIFF
--- a/template/src/pages/Create.tsx
+++ b/template/src/pages/Create.tsx
@@ -10,12 +10,7 @@
 *********************************************
 */
 import React, {useState} from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Dimensions,
-} from 'react-native';
+import {View, Text, StyleSheet, Dimensions, ScrollView} from 'react-native';
 import {useHistory} from '../components/Router';
 import Checkbox from '../subComponents/Checkbox';
 import {gql, useMutation} from '@apollo/client';
@@ -38,8 +33,16 @@ type PasswordInput = {
 };
 
 const CREATE_CHANNEL = gql`
-  mutation CreateChannel($title: String!, $backendURL: String!, $enablePSTN: Boolean) {
-    createChannel(title: $title, backendURL: $backendURL, enablePSTN: $enablePSTN) {
+  mutation CreateChannel(
+    $title: String!
+    $backendURL: String!
+    $enablePSTN: Boolean
+  ) {
+    createChannel(
+      title: $title
+      backendURL: $backendURL
+      enablePSTN: $enablePSTN
+    ) {
       passphrase {
         host
         view
@@ -111,7 +114,7 @@ const Create = () => {
     //   style={style.full}
     //   resizeMode={'cover'}>
     // <KeyboardAvoidingView behavior={'height'} style={style.main}>
-    <View style={style.main}>
+    <ScrollView contentContainerStyle={style.main}>
       <View style={style.nav}>
         <Logo />
         {error ? <Error error={error} /> : <></>}
@@ -179,17 +182,17 @@ const Create = () => {
           roomTitle={roomTitle}
         />
       )}
-    </View>
+    </ScrollView>
   );
 };
 
 const style = StyleSheet.create({
-  full: {flex: 1},
   main: {
-    flex: 2,
-    justifyContent: 'space-evenly',
+    paddingVertical: '8%',
     marginHorizontal: '8%',
-    marginVertical: '2%',
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    flexGrow: 1,
   },
   nav: {
     flex: 1,

--- a/template/src/pages/Join.tsx
+++ b/template/src/pages/Join.tsx
@@ -10,11 +10,7 @@
 *********************************************
 */
 import React, {useContext, useState} from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-} from 'react-native';
+import {View, Text, StyleSheet, ScrollView} from 'react-native';
 import {useHistory} from '../components/Router';
 import SessionContext from '../components/SessionContext';
 // import OpenInNativeButton from '../subComponents/OpenInNativeButton';
@@ -38,8 +34,9 @@ const Join = (props: joinProps) => {
   const history = useHistory();
   const {primaryColor} = useContext(ColorContext);
   const {joinSession} = useContext(SessionContext);
-  const [error, setError] =
-    useState<null | {name: string; message: string}>(null);
+  const [error, setError] = useState<null | {name: string; message: string}>(
+    null,
+  );
   // const [dim, setDim] = useState([
   //   Dimensions.get('window').width,
   //   Dimensions.get('window').height,
@@ -57,18 +54,12 @@ const Join = (props: joinProps) => {
   const startCall = async () => {
     joinSession({phrase});
   };
-  // throw new Error("My first Sentry error!");
+
   return (
-    // <ImageBackground
-    //   // onLayout={onLayout}
-    //   style={style.full}
-    //   resizeMode={'cover'}>
-    <View style={style.main}>
-      {/* <KeyboardAvoidingView behavior={'height'} style={style.main}> */}
+    <ScrollView contentContainerStyle={style.main}>
       <View style={style.nav}>
         <Logo />
         {error ? <Error error={error} /> : <></>}
-        {/* <OpenInNativeButton /> */}
       </View>
       <View style={style.content}>
         <View style={style.leftContent}>
@@ -99,28 +90,19 @@ const Join = (props: joinProps) => {
             )}
           </View>
         </View>
-        {/* {dim[0] > dim[1] + 150 ? (
-            <View style={style.full}>
-              <Illustration />
-            </View>
-          ) : (
-            <></>
-          )} */}
       </View>
-      {/* </KeyboardAvoidingView> */}
-    </View>
-    // </ImageBackground>
+    </ScrollView>
   );
 };
 
 const style = StyleSheet.create({
-  full: {flex: 1},
   illustration: {flex: 1, alignSelf: 'flex-end'},
   main: {
-    flex: 2,
-    justifyContent: 'space-evenly',
+    paddingVertical: '8%',
     marginHorizontal: '8%',
-    marginVertical: '2%',
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    flexGrow: 1,
   },
   nav: {
     flex: 1,


### PR DESCRIPTION
# Related Issue
- Elements in "Create meeting" and "Join using meeting ID" page overlap because of space restrictions
- Clickup Issue: https://app.clickup.com/t/51c2ae

# Propossed changes/Fix
- Add scrollview container, when height is less the elements scroll smoothly thereby not cramping the view by overalapping the elements
- Add css to scrollview container, when elements are less they cover the entire available height and space out evenly.

# Additional Info 
- Videos enclosed have dummy text to test the overflowing scenario, final code push does not have those changes.

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

Tested on electron, ios, web(safari)

# Dependent PRs 
- NA

# Screenshots
<img width="407" alt="create_meeting_screen" src="https://user-images.githubusercontent.com/22396308/138300091-0f8e0286-2d09-468f-962c-1cc2bed36318.png">

Videos on safari and iphone with additional texts:

[crampedui_ios.zip](https://github.com/AgoraIO-Community/app-builder-core/files/7390126/crampedui_ios.zip)

PS: Unable to add safari video here, will attach both the videos on clickup issue as well