### PR TITLE
Hide brand logo when not selected

### DIFF
--- a/template/src/components/Precall.tsx
+++ b/template/src/components/Precall.tsx
@@ -19,6 +19,7 @@ import {LocalAudioMute, LocalVideoMute} from '../../agora-rn-uikit/Components';
 import LocalUserContext from '../../agora-rn-uikit/src/LocalUserContext';
 import SelectDevice from '../subComponents/SelectDevice';
 import Logo from '../subComponents/Logo';
+import hasBrandLogo from '../utils/hasBrandLogo';
 // import OpenInNativeButton from '../subComponents/OpenInNativeButton';
 import ColorContext from './ColorContext';
 // import {useHistory} from './Router';
@@ -45,7 +46,7 @@ const Precall = (props: any) => {
     //   resizeMode={'cover'}>
     <View style={style.main} onLayout={onLayout}>
       <View style={style.nav}>
-        <Logo />
+        {hasBrandLogo && <Logo />}
         {error ? <Error error={error} showBack={true} /> : <></>}
         {/* <OpenInNativeButton /> */}
       </View>

--- a/template/src/pages/Authenticate.tsx
+++ b/template/src/pages/Authenticate.tsx
@@ -20,6 +20,7 @@ import {
 import Logo from '../subComponents/Logo';
 import OAuth from '../components/OAuth';
 import Illustration from '../subComponents/Illustration';
+import hasBrandLogo from '../utils/hasBrandLogo';
 
 const Authenticate = () => {
   const [dim, setDim] = useState([
@@ -37,13 +38,13 @@ const Authenticate = () => {
       style={style.full}
       resizeMode={'cover'}>
       <View style={style.main}>
-        <View style={style.nav}>
-          <Logo />
-        </View>
+        <View style={style.nav}>{hasBrandLogo && <Logo />}</View>
         <View style={style.content}>
           <View style={style.leftContent}>
             <Text style={style.heading}>Login using OAuth</Text>
-            <Text style={style.headline}>Please select an OAuth provider to login.</Text>
+            <Text style={style.headline}>
+              Please select an OAuth provider to login.
+            </Text>
             <OAuth />
           </View>
           {dim[0] > dim[1] + 150 ? (

--- a/template/src/pages/Create.tsx
+++ b/template/src/pages/Create.tsx
@@ -26,6 +26,7 @@ import HorizontalRule from '../atoms/HorizontalRule';
 import TextInput from '../atoms/TextInput';
 import Error from '../subComponents/Error';
 import Toast from '../../react-native-toast-message';
+import hasBrandLogo from '../utils/hasBrandLogo';
 
 type PasswordInput = {
   host: string;
@@ -116,7 +117,7 @@ const Create = () => {
     // <KeyboardAvoidingView behavior={'height'} style={style.main}>
     <ScrollView contentContainerStyle={style.main}>
       <View style={style.nav}>
-        <Logo />
+        {hasBrandLogo && <Logo />}
         {error ? <Error error={error} /> : <></>}
         {/* <OpenInNativeButton /> */}
       </View>

--- a/template/src/pages/Join.tsx
+++ b/template/src/pages/Join.tsx
@@ -15,6 +15,7 @@ import {useHistory} from '../components/Router';
 import SessionContext from '../components/SessionContext';
 // import OpenInNativeButton from '../subComponents/OpenInNativeButton';
 import Logo from '../subComponents/Logo';
+import hasBrandLogo from '../utils/hasBrandLogo';
 import LogoutButton from '../subComponents/LogoutButton';
 import ColorContext from '../components/ColorContext';
 // import Illustration from '../subComponents/Illustration';
@@ -58,7 +59,7 @@ const Join = (props: joinProps) => {
   return (
     <ScrollView contentContainerStyle={style.main}>
       <View style={style.nav}>
-        <Logo />
+        {hasBrandLogo && <Logo />}
         {error ? <Error error={error} /> : <></>}
       </View>
       <View style={style.content}>

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -30,6 +30,7 @@ import {gql, useQuery} from '@apollo/client';
 // import Watermark from '../subComponents/Watermark';
 import StorageContext from '../components/StorageContext';
 import Logo from '../subComponents/Logo';
+import hasBrandLogo from '../utils/hasBrandLogo';
 import ChatContext from '../components/ChatContext';
 import {SidePanelType} from '../subComponents/SidePanelEnum';
 import {videoView} from '../../theme.json';
@@ -465,9 +466,7 @@ const VideoCall: React.FC = () => {
         </>
       ) : (
         <View style={style.loader}>
-          <View style={style.loaderLogo}>
-            <Logo />
-          </View>
+          <View style={style.loaderLogo}>{hasBrandLogo && <Logo />}</View>
           <Text style={style.loaderText}>Starting Call. Just a second.</Text>
         </View>
       )}

--- a/template/src/subComponents/SelectOAuth.tsx
+++ b/template/src/subComponents/SelectOAuth.tsx
@@ -17,56 +17,69 @@ import apple from '../assets/apple.png';
 import slack from '../assets/slack.png';
 import microsoft from '../assets/microsoft.png';
 import Logo from './Logo';
+import hasBrandLogo from '../utils/hasBrandLogo';
 
 const SelectOAuth = ({onSelectOAuth}) => {
   // Linking.openURL(url);
   const {primaryColor} = useContext(ColorContext);
   return (
     <View style={style.main}>
-      <View style={style.nav}>
-        <Logo />
-      </View>
+      <View style={style.nav}>{hasBrandLogo && <Logo />}</View>
       <View style={style.content}>
         <View style={style.leftContent}>
           <Text style={style.heading}>{$config.APP_NAME}</Text>
           <Text style={style.headline}>{$config.LANDING_SUB_HEADING}</Text>
           <View style={style.inputs}>
             <View style={style.oAuthContainer}>
-              <Text style={{fontSize: 16, fontWeight: '500', marginBottom: 20, color: $config.PRIMARY_FONT_COLOR}}>
+              <Text
+                style={{
+                  fontSize: 16,
+                  fontWeight: '500',
+                  marginBottom: 20,
+                  color: $config.PRIMARY_FONT_COLOR,
+                }}>
                 Login using OAuth
               </Text>
-              {$config.ENABLE_GOOGLE_OAUTH ?
+              {$config.ENABLE_GOOGLE_OAUTH ? (
                 <TouchableOpacity
                   style={[style.secondaryBtn, {borderColor: primaryColor}]}
                   onPress={() => onSelectOAuth({oAuthSystem: 'google'})}>
                   <Image source={google} style={style.logo} />
                   <Text style={[style.secondaryBtnText]}>Google</Text>
                 </TouchableOpacity>
-                : <></>}
-              {$config.ENABLE_MICROSOFT_OAUTH ?
+              ) : (
+                <></>
+              )}
+              {$config.ENABLE_MICROSOFT_OAUTH ? (
                 <TouchableOpacity
                   style={[style.secondaryBtn, {borderColor: primaryColor}]}
                   onPress={() => onSelectOAuth({oAuthSystem: 'microsoft'})}>
                   <Image source={microsoft} style={style.logo} />
                   <Text style={[style.secondaryBtnText]}>Microsoft</Text>
                 </TouchableOpacity>
-                : <></>}
-              {$config.ENABLE_SLACK_OAUTH ?
+              ) : (
+                <></>
+              )}
+              {$config.ENABLE_SLACK_OAUTH ? (
                 <TouchableOpacity
                   style={[style.secondaryBtn, {borderColor: primaryColor}]}
                   onPress={() => onSelectOAuth({oAuthSystem: 'slack'})}>
                   <Image source={slack} style={style.logo} />
                   <Text style={[style.secondaryBtnText]}>Slack</Text>
                 </TouchableOpacity>
-                : <></>}
-              {$config.ENABLE_APPLE_OAUTH ?
+              ) : (
+                <></>
+              )}
+              {$config.ENABLE_APPLE_OAUTH ? (
                 <TouchableOpacity
                   style={[style.secondaryBtn, {borderColor: primaryColor}]}
                   onPress={() => onSelectOAuth({oAuthSystem: 'apple'})}>
                   <Image source={apple} style={style.logo} />
                   <Text style={[style.secondaryBtnText]}>Apple</Text>
                 </TouchableOpacity>
-                : <></>}
+              ) : (
+                <></>
+              )}
             </View>
           </View>
         </View>

--- a/template/src/utils/hasBrandLogo.tsx
+++ b/template/src/utils/hasBrandLogo.tsx
@@ -1,0 +1,3 @@
+const hasBrandLogo: boolean = !!$config.LOGO;
+
+export default hasBrandLogo;


### PR DESCRIPTION
# Related Issue
- Issue Description: On app builder application, user has the option to
a) Keep the logo as it is
b) Replace the logo with new file
c) Remove the logo completely.
When the user opts for option "c", the logo is not removed but is replaced with transparent image. 
When the cursor hovers over this section, it changes to pointer and the "onClick" event is also executed which is not the expected behaviour.
- Clickup ticket: https://app.clickup.com/t/1te00d9

# Propossed changes/Fix
- Display logo image only when LOGO field in config.json exists
- Added a util method "hasBrandLogo" to check if logo field in config.json has data.

# Additional Info 
- NA

# Checklist
- [X] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [X] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- NA

# Screenshots

Original                       
:-----------------------:
<img width="1116" alt="logo-removed-before" src="https://user-images.githubusercontent.com/22396308/139436041-13a9456d-78b5-4544-bfb4-61234babc6f2.png">

Updated
:-----------------------:  
<img width="1119" alt="logo-removed" src="https://user-images.githubusercontent.com/22396308/139435728-a784cfab-b3f1-4847-81b3-d9494465999d.png">
*

Config.json file generated when logo is selected:
when logo is empty, the config.json file generated inside also has empty string

<img width="1415" alt="Screenshot 2021-11-02 at 4 50 25 PM" src="https://user-images.githubusercontent.com/22396308/139837356-17c09a24-555f-4830-b451-a5ffa05e52ba.png">
;
