### PR TITLE
updated electron version and added babel plugin for optional chaining

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@babel/core": "7.14.3",
     "@babel/plugin-proposal-class-properties": "7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.16.0",
     "@babel/preset-env": "7.14.4",
     "@babel/preset-react": "7.13.13",
     "@babel/preset-typescript": "7.13.0",
@@ -92,7 +93,7 @@
     "babel-plugin-transform-define": "2.0.0",
     "cross-env": "7.0.3",
     "del": "5.1.0",
-    "electron": "5.0.8",
+    "electron": "16.0.1",
     "electron-builder": "22.10.5",
     "electron-notarize": "1.0.0",
     "eslint": "6.8.0",

--- a/template/webpack.commons.js
+++ b/template/webpack.commons.js
@@ -94,6 +94,7 @@ module.exports = {
             plugins: [
               // Adds support for class properties
               ['transform-define', configVars],
+              '@babel/plugin-proposal-optional-chaining',
               '@babel/plugin-proposal-class-properties',
               isDevelopment && require.resolve('react-refresh/babel'),
             ].filter(Boolean),


### PR DESCRIPTION
# Related Issue
- Electron build was failing due to outdated version of electron
- Web build was failing, optional chaining loader was not getting identified. 

# Propossed changes/Fix
- Updated electron version
- added new babel plugin for optional chaining 

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.
