### PR TITLE
Fixed issue on username is hidden in the backdrop

### DIFF
--- a/template/src/components/GridVideo.tsx
+++ b/template/src/components/GridVideo.tsx
@@ -97,8 +97,8 @@ const GridVideo = (props: GridVideoProps) => {
                 marginHorizontal: 'auto',
               }}
               key={cidx}>
-              <ScreenShareNotice uid={users[ridx * dims.c + cidx].uid} />
               <View style={style.gridVideoContainerInner}>
+                <ScreenShareNotice uid={users[ridx * dims.c + cidx].uid} />
                 <MaxVideoView
                   fallback={() => {
                     if (users[ridx * dims.c + cidx].uid === 'local') {
@@ -116,6 +116,7 @@ const GridVideo = (props: GridVideoProps) => {
                 />
                 <View
                   style={{
+                    zIndex:5,
                     marginTop: -30,
                     backgroundColor: $config.SECONDARY_FONT_COLOR + 'bb',
                     alignSelf: 'flex-end',
@@ -211,7 +212,7 @@ const style = StyleSheet.create({
     flex: 1,
     overflow: 'hidden',
     // margin: 1,
-    paddingHorizontal: 10,
+    marginHorizontal: 10,
   },
   MicBackdrop: {
     width: 20,

--- a/template/src/components/PinnedVideo.tsx
+++ b/template/src/components/PinnedVideo.tsx
@@ -194,9 +194,9 @@ const PinnedVideo = () => {
         }>
         <MaxUidConsumer>
           {(maxUsers) => (
-            <>
-            <ScreenShareNotice uid={maxUsers[0].uid} />
+            <>            
             <View style={style.flex1}>
+              <ScreenShareNotice uid={maxUsers[0].uid} />
               <MaxVideoView
                 fallback={() => {
                   if (maxUsers[0].uid === 'local') {
@@ -261,6 +261,7 @@ const style = StyleSheet.create({
     borderTopLeftRadius: 15,
     borderBottomRightRadius: 15,
     flexDirection: 'row',
+    zIndex: 5
   },
   name: {color: $config.PRIMARY_FONT_COLOR, lineHeight: 25, fontWeight: '700'},
   MicBackdrop: {


### PR DESCRIPTION
# Related Issue
- Screen sharing overlay backdrop hides the username(righthand bottom side)
- [clickup ticket](https://app.clickup.com/t/e5chm5)

# Propossed changes/Fix
- Added zindex for the username text for pinned and grid video files

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original                
<img width="1792" alt="Screenshot 2021-12-07 at 2 29 09 PM" src="https://user-images.githubusercontent.com/13586565/145000236-2b1cd45a-3a95-4976-8a0d-5d86fe85ea05.png">

Updated
<img width="1781" alt="Screenshot 2021-12-07 at 2 32 19 PM" src="https://user-images.githubusercontent.com/13586565/145000287-a79f33fa-cacc-4cb6-a5f9-838eacebb00a.png">

