### PR TITLE
Added responsive font size plugin for displaying username in grid/pinned layout 

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -64,6 +64,7 @@
     "react-native-inappbrowser-reborn": "3.5.1",
     "react-native-keep-awake": "4.0.0",
     "react-native-keyboard-manager": "6.5.4-1",
+    "react-native-responsive-fontsize": "^0.5.1",
     "react-native-web": "0.14.13",
     "react-router-dom": "5.2.0",
     "react-router-native": "5.2.0"

--- a/template/package.json
+++ b/template/package.json
@@ -64,7 +64,7 @@
     "react-native-inappbrowser-reborn": "3.5.1",
     "react-native-keep-awake": "4.0.0",
     "react-native-keyboard-manager": "6.5.4-1",
-    "react-native-responsive-fontsize": "^0.5.1",
+    "react-native-responsive-fontsize": "0.5.1",
     "react-native-web": "0.14.13",
     "react-router-dom": "5.2.0",
     "react-router-native": "5.2.0"

--- a/template/src/components/GridVideo.tsx
+++ b/template/src/components/GridVideo.tsx
@@ -18,6 +18,7 @@ import {
   Dimensions,
   Image,
   Pressable,
+  useWindowDimensions
 } from 'react-native';
 import MinUidContext from '../../agora-rn-uikit/src/MinUidContext';
 import MaxUidContext from '../../agora-rn-uikit/src/MaxUidContext';
@@ -30,6 +31,7 @@ import FallbackLogo from '../subComponents/FallbackLogo';
 import Layout from '../subComponents/LayoutEnum';
 import RtcContext, {DispatchType} from '../../agora-rn-uikit/src/RtcContext';
 import ScreenShareNotice from '../subComponents/ScreenShareNotice';
+import { RFValue } from "react-native-responsive-fontsize";
 
 const layout = (len: number, isDesktop: boolean = true) => {
   const rows = Math.round(Math.sqrt(len));
@@ -56,6 +58,7 @@ interface GridVideoProps {
 }
 
 const GridVideo = (props: GridVideoProps) => {
+  const { height, width } = useWindowDimensions();
   const {dispatch} = useContext(RtcContext);
   const max = useContext(MaxUidContext);
   const min = useContext(MinUidContext);
@@ -151,12 +154,13 @@ const GridVideo = (props: GridVideoProps) => {
                     />
                   </View>
                   <Text
+                    numberOfLines={1}
                     textBreakStrategy={'simple'}
                     style={{
                       color: $config.PRIMARY_FONT_COLOR,
                       lineHeight: 30,
-                      fontSize: 18,
-                      fontWeight: '600',
+                      fontSize: RFValue(14, height > width ? height : width),
+                      fontWeight: '700',
                       // width: '100%',
                       // alignSelf: 'stretch',
                       // textAlign: 'center',

--- a/template/src/components/PinnedVideo.tsx
+++ b/template/src/components/PinnedVideo.tsx
@@ -18,6 +18,7 @@ import {
   Text,
   Image,
   Pressable,
+  useWindowDimensions
 } from 'react-native';
 import {MinUidConsumer} from '../../agora-rn-uikit/src/MinUidContext';
 import RtcContext from '../../agora-rn-uikit/src/RtcContext';
@@ -29,10 +30,11 @@ import icons from '../assets/icons';
 import {layoutProps} from '../../theme.json';
 import FallbackLogo from '../subComponents/FallbackLogo';
 import ScreenShareNotice from '../subComponents/ScreenShareNotice';
-
+import { RFValue } from "react-native-responsive-fontsize";
 const {topPinned} = layoutProps;
 
 const PinnedVideo = () => {
+  const { height, width } = useWindowDimensions();
   const {primaryColor} = useContext(ColorContext);
   const [collapse, setCollapse] = useState(false);
   const [dim, setDim] = useState([
@@ -162,7 +164,7 @@ const PinnedVideo = () => {
                               resizeMode={'contain'}
                             />
                           </View>
-                          <Text style={style.name}>
+                          <Text numberOfLines={1} style={[style.name,{fontSize: RFValue(14, height > width ? height : width)}]}>
                             {user.uid === 'local'
                               ? userList[localUid]
                                 ? userList[localUid].name.slice(0, 20) + ' '
@@ -225,7 +227,7 @@ const PinnedVideo = () => {
                     resizeMode={'contain'}
                   />
                 </View>
-                <Text style={style.name}>
+                <Text numberOfLines={1} style={[style.name, {fontSize: RFValue(14, height > width ? height : width)}]}>
                   {maxUsers[0].uid === 'local'
                     ? userList[localUid]
                       ? userList[localUid].name.slice(0,20) + ' '
@@ -261,7 +263,8 @@ const style = StyleSheet.create({
     borderTopLeftRadius: 15,
     borderBottomRightRadius: 15,
     flexDirection: 'row',
-    zIndex: 5
+    zIndex: 5,
+    maxWidth: '100%'
   },
   name: {color: $config.PRIMARY_FONT_COLOR, lineHeight: 25, fontWeight: '700'},
   MicBackdrop: {


### PR DESCRIPTION
# Related Issue
- Mobile Web UI: Usernames are overflowing
- [clickup ticket](https://app.clickup.com/t/ew4e36)

# Propossed changes/Fix
- Install and use react-native-responsive-fontsize plugin
- Updated the fontsize in grid/pinned layout usernames

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [x] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original               
<img width="543" alt="Screenshot 2021-12-14 at 5 24 14 PM" src="https://user-images.githubusercontent.com/13586565/145994333-00f9169c-6e1b-4a11-b8ed-544367e0bf66.png">

Updated
<img width="505" alt="Screenshot 2021-12-14 at 5 26 11 PM" src="https://user-images.githubusercontent.com/13586565/145994362-0be42056-395c-49c9-8678-0a75b644c449.png">

