### PR TITLE
Fixed issue that setting icon not rendering in mobile web

### DIFF
--- a/template/src/components/Navbar.tsx
+++ b/template/src/components/Navbar.tsx
@@ -251,18 +251,24 @@ const Navbar = (props: any) => {
               </TouchableOpacity>
             </View>
           </View>
-          {Platform.OS === 'web' && isDesktop ? (
+          {/** Show setting icon only in non native apps 
+           * show in web/electron/mobile web
+           * hide in android/ios  */}
+          {(Platform.OS !== 'android' && Platform.OS !== 'ios') ? (
             <>
-              <View
-                style={{
-                  backgroundColor: $config.PRIMARY_FONT_COLOR + '80',
-                  width: 1,
-                  height: '100%',
-                  marginHorizontal: 10,
-                  alignSelf: 'center',
-                  opacity: 0.8,
-                }}
-              />
+              { 
+                (Platform.OS === 'web' && isDesktop) &&
+                <View
+                  style={{
+                    backgroundColor: $config.PRIMARY_FONT_COLOR + '80',
+                    width: 1,
+                    height: '100%',
+                    marginHorizontal: 10,
+                    alignSelf: 'center',
+                    opacity: 0.8,
+                  }}
+                />
+              }
               <View style={{width: '20%', height: '100%'}}>
                 <Settings
                   sidePanel={sidePanel}


### PR DESCRIPTION
# Related Issue
- Settings icon not rendering on mobile web
- clickup ticket - https://app.clickup.com/t/1tya9a8

# Propossed changes/Fix
- Updated condition not display in mobile - android/ios

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original                
<img width="600" alt="Screenshot 2021-12-16 at 6 06 01 PM" src="https://user-images.githubusercontent.com/13586565/146373618-b5ce562f-a79a-4e6d-a2ee-9a7361b650b3.png">

Updated
<img width="599" alt="Screenshot 2021-12-16 at 6 00 49 PM" src="https://user-images.githubusercontent.com/13586565/146373642-8a15d731-4364-4337-9ee1-ec5fa0ff1114.png">


