### PR TITLE
Fixed textinput content overflow on iphone

### DIFF
--- a/template/src/atoms/TextInput.tsx
+++ b/template/src/atoms/TextInput.tsx
@@ -19,7 +19,7 @@ const PrimaryButton = (props: TextInputProps) => {
   const {style, ...otherProps} = props;
   return (
     <TextInput
-      style={[styles.textInput, style, styles.noOutline, {borderColor: primaryColor, color: $config.PRIMARY_FONT_COLOR}]}
+      style={[styles.textInput, styles.textWrapFix, style, styles.noOutline, {borderColor: primaryColor, color: $config.PRIMARY_FONT_COLOR}]}
       placeholderTextColor={$config.PRIMARY_FONT_COLOR + '70'}
       {...otherProps}
       autoCorrect={false}
@@ -32,4 +32,9 @@ export default PrimaryButton;
 const styles = StyleSheet.create({
   textInput,
   noOutline: Platform.OS === 'web' ? { outlineStyle: "none" } : {},
+  textWrapFix: Platform.select({
+    ios: {
+      paddingVertical: 5
+    }
+  })
 });


### PR DESCRIPTION
# Related Issue
- Enter Meeting ID input overflowing in iPhone
- clickup ticket -https://app.clickup.com/t/1wupwpw

# Proposed changes/Fix
- Added padding vertical to fix the wrapping issue

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original               
![Simulator Screen Shot - iPhone 12 mini - 2021-12-21 at 18 55 39](https://user-images.githubusercontent.com/13586565/146938878-3e309e4c-dd26-4f26-a7a2-7bffe491b635.png)

Updated
![Simulator Screen Shot - iPhone 12 mini - 2021-12-21 at 18 55 23](https://user-images.githubusercontent.com/13586565/146938904-3912c1ca-b1fd-46da-ad5f-baa542a58b59.png)

