### PR TITLE
Fixed - RTM Join doesn't reconnect on its own on failure

### DIFF
--- a/template/src/components/RTMConfigure.tsx
+++ b/template/src/components/RTMConfigure.tsx
@@ -64,6 +64,7 @@ const RtmConfigure = (props: any) => {
   const [userList, setUserList] = useState<{[key: string]: any}>({});
   let engine = useRef<RtmEngine>(null!);
   let localUid = useRef<string>('');
+  const timerValueRef: any = useRef(5);
 
   const addMessageToStore = (uid: string, msg: {body: string; ts: string}) => {
     setMessageStore((m: messageStoreInterface[]) => {
@@ -95,12 +96,119 @@ const RtmConfigure = (props: any) => {
       return {...newState};
     });
   };
+  
+  const doLoginAndSetupRTM = async () => {
+    try {
+      await engine.current.login({
+        uid: localUid.current,
+        token: rtcProps.rtm,
+      });
+      timerValueRef.current = 5
+      setAttribute();      
+    } catch (error) {
+      setTimeout( async () => {
+        timerValueRef.current = timerValueRef.current + timerValueRef.current;
+        doLoginAndSetupRTM();
+      }, timerValueRef.current * 1000 );
+    }
+  }
 
+  const setAttribute = async () => {    
+    try {
+      await engine.current.setLocalUserAttributes([
+        {key: 'name', value: name || 'User'},
+        {key: 'screenUid', value: String(rtcProps.screenShareUid)},
+      ]);
+      timerValueRef.current = 5
+      joinChannel()            
+    } catch (error) {
+      setTimeout( async () => {
+        timerValueRef.current = timerValueRef.current + timerValueRef.current;
+        setAttribute();
+      }, timerValueRef.current * 1000 );
+    }
+  }
+
+  const joinChannel = async () => {
+    try {
+      await engine.current.joinChannel(rtcProps.channel);  
+      timerValueRef.current = 5
+      getMembers()      
+    } catch (error) {
+      setTimeout( async () => {
+        timerValueRef.current = timerValueRef.current + timerValueRef.current;
+        joinChannel();
+      }, timerValueRef.current * 1000 );
+    }  
+  }
+
+  const getMembers = async () => {
+    try {
+      await engine.current
+      .getChannelMembersBychannelId(rtcProps.channel)
+      .then((data) => {
+        data.members.map(async (member: any) => {
+          const backoffAttributes = backOff(
+            async () => {
+              const attr = await engine.current.getUserAttributesByUid(
+                member.uid,
+              );
+              if (attr?.attributes?.name && attr?.attributes?.screenUid) {
+                return attr;
+              } else {
+                throw attr;
+              }
+            },
+            {
+              retry: (e, idx) => {
+                console.log(
+                  `[retrying] Attempt ${idx}. Fetching ${member.uid}'s name`,
+                  e,
+                );
+                return true;
+              },
+            },
+          );
+          try {
+            const attr = await backoffAttributes;
+            console.log('[user attributes]:', {attr});
+            setUserList((prevState) => {
+              return {
+                ...prevState,
+                [member.uid]: {
+                  name: attr?.attributes?.name || 'User',
+                  type: UserType.Normal,
+                  screenUid: parseInt(attr?.attributes?.screenUid),
+                },
+                [parseInt(attr?.attributes?.screenUid)]: {
+                  name: `${attr?.attributes?.name || 'User'}'s screenshare`,
+                  type: UserType.ScreenShare,
+                },
+              };
+            });
+          } catch (e) {
+            console.error(`Could not retrieve name of ${member.uid}`, e);
+          }
+        });
+        setLogin(true);
+        console.log('RTM init done');
+      });
+      timerValueRef.current = 5
+    } catch (error) {
+      setTimeout( async () => {
+        timerValueRef.current = timerValueRef.current + timerValueRef.current;
+        getMembers();
+      }, timerValueRef.current * 1000 );
+    } 
+  }
   const init = async () => {
     engine.current = new RtmEngine();
     rtcProps.uid
       ? (localUid.current = rtcProps.uid + '')
       : (localUid.current = '' + timeNow());
+    engine.current.on('connectionStateChanged', (evt: any) => {
+       //console.log(evt);
+    });
     engine.current.on('error', (evt: any) => {
       // console.log(evt);
     });
@@ -283,65 +391,9 @@ const RtmConfigure = (props: any) => {
       });
     });
 
-    engine.current.createClient(rtcProps.appId);
-    await engine.current.login({
-      uid: localUid.current,
-      token: rtcProps.rtm,
-    });
-    await engine.current.setLocalUserAttributes([
-      {key: 'name', value: name || 'User'},
-      {key: 'screenUid', value: String(rtcProps.screenShareUid)},
-    ]);
-    await engine.current.joinChannel(rtcProps.channel);
-    engine.current
-      .getChannelMembersBychannelId(rtcProps.channel)
-      .then((data) => {
-        data.members.map(async (member: any) => {
-          const backoffAttributes = backOff(
-            async () => {
-              const attr = await engine.current.getUserAttributesByUid(
-                member.uid,
-              );
-              if (attr?.attributes?.name && attr?.attributes?.screenUid) {
-                return attr;
-              } else {
-                throw attr;
-              }
-            },
-            {
-              retry: (e, idx) => {
-                console.log(
-                  `[retrying] Attempt ${idx}. Fetching ${member.uid}'s name`,
-                  e,
-                );
-                return true;
-              },
-            },
-          );
-          try {
-            const attr = await backoffAttributes;
-            console.log('[user attributes]:', {attr});
-            setUserList((prevState) => {
-              return {
-                ...prevState,
-                [member.uid]: {
-                  name: attr?.attributes?.name || 'User',
-                  type: UserType.Normal,
-                  screenUid: parseInt(attr?.attributes?.screenUid),
-                },
-                [parseInt(attr?.attributes?.screenUid)]: {
-                  name: `${attr?.attributes?.name || 'User'}'s screenshare`,
-                  type: UserType.ScreenShare,
-                },
-              };
-            });
-          } catch (e) {
-            console.error(`Could not retrieve name of ${member.uid}`, e);
-          }
-        });
-        setLogin(true);
-      });
-    console.log('RTM init done');
+    await engine.current.createClient(rtcProps.appId);
+    doLoginAndSetupRTM();
+    
   };
 
   const sendMessage = async (msg: string) => {


### PR DESCRIPTION
# Related Issue
- RTM Join doesn't reconnect on its own on failure
- [clickup ticket](https://app.clickup.com/t/1wn6guf)

# Propossed changes/Fix
- Added try catch and retry mechanism for rtm login/join 

# Additional Info 
- There is no issue with web-socket failure and reconnect when internet is very slow. only issue if internet got failed during rtm login or join channel. there is no code to retry the operation.. so added the retry logic
- Used network link conditioner tool to limit internet 
- Note: Chrome network throttler won't limit the webRTC or RTM web-socket. it will only restrict http connection

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots
- N/A