### PR TITLE
Fixed nav bar icon size not consistent

### DIFF
--- a/template/src/components/Navbar.tsx
+++ b/template/src/components/Navbar.tsx
@@ -158,7 +158,8 @@ const Navbar = (props: any) => {
               Platform.OS === 'web'
                 ? $config.SECONDARY_FONT_COLOR
                 : $config.SECONDARY_FONT_COLOR + '00',
-            padding: 4,
+            paddingVertical: 4,
+            paddingHorizontal: mobileAndTabletCheck() ? 0 : 4,
             minHeight: 35,
             // height: 40,
             // backgroundColor: '#f0f',
@@ -168,7 +169,7 @@ const Navbar = (props: any) => {
               Platform.OS === 'web' && isDesktop
                 ? 300
                 : mobileAndTabletCheck()
-                ? 150
+                ? 160
                 : 200,
             // borderTopLeftRadius: 10,
             // borderBottomLeftRadius: 10,
@@ -205,15 +206,7 @@ const Navbar = (props: any) => {
               ) : (
                 <></>
               )}
-              <View style={{width: '25%', height: '120%'}}>
-                <View style={{width: '100%', height: '110%'}}>
-                  <View
-                    style={{
-                      alignSelf: 'center',
-                      width: '100%',
-                      height: '100%',
-                      position: 'relative',
-                    }}>
+              <View style={{width: '20%', height: '100%', position: 'relative'}}>
                     <BtnTemplate
                       style={style.btnHolder}
                       onPress={() => {
@@ -230,7 +223,7 @@ const Navbar = (props: any) => {
                           : 'chatIcon'
                       }
                     />
-                    <View style={{position: 'absolute', top: 5}}>
+                    <View style={{position: 'absolute', top: Platform.OS === 'web' ? 1 : -15, left: ( Platform.OS === 'web' && isDesktop) ? 10 : 1 }}>
                       {sidePanel !== SidePanelType.Chat &&
                       pendingMessageLength !== 0 ? (
                         <View style={style.chatNotification}>
@@ -243,8 +236,6 @@ const Navbar = (props: any) => {
                       )}
                     </View>
                   </View>
-                </View>
-              </View>
             </>
           ) : (
             <></>
@@ -263,8 +254,7 @@ const Navbar = (props: any) => {
           ) : (
             <></>
           )}
-          <View style={{width: '20%', height: '120%'}}>
-            <View style={{alignSelf: 'center', width: '100%', height: '105%'}}>
+          <View style={{width: '20%', height: '100%'}}>
               <BtnTemplate
                 style={style.btnHolder}
                 onPress={() => {
@@ -274,7 +264,6 @@ const Navbar = (props: any) => {
                 }}
                 name={layout ? 'gridLayoutFilledIcon' : 'pinnedLayoutIcon'}
               />
-            </View>
           </View>
           {/** Show setting icon only in non native apps
            * show in web/electron/mobile web
@@ -346,8 +335,8 @@ const style = StyleSheet.create({
     margin: 1,
     resizeMode: 'contain',
   },
-  btnHolder: {
-    padding: mobileAndTabletCheck() ? 2 : 5,
+  btnHolder: {   
+    marginHorizontal: mobileAndTabletCheck() ? 2 : 0, 
     width: '100%',
     height: '100%',
     resizeMode: 'contain',

--- a/template/src/components/Settings.tsx
+++ b/template/src/components/Settings.tsx
@@ -24,7 +24,7 @@ const Settings = (props: any) => {
 
   return (
     <BtnTemplate
-      style={[style.localButton, {borderColor: primaryColor}]}
+      style={[style.localButtonWithMatchingStyle, {borderColor: primaryColor}]}
       onPress={() => {
         sidePanel === SidePanelType.Settings
           ? setSidePanel(SidePanelType.None)
@@ -107,6 +107,11 @@ const style = StyleSheet.create({
     justifyContent: 'center',
     resizeMode: 'contain',
   },
+  localButtonWithMatchingStyle:{    
+    width: '100%',
+    height: '100%',
+    resizeMode: 'contain',
+  }
 });
 
 export default Settings;


### PR DESCRIPTION
# Related Issue
- Navigation Bar Icon size not consistent across different screen-size
- clickup ticket https://app.clickup.com/t/1xbzfgy

# Propossed changes/Fix
- Remove the extra view and different height percentage 
- Adjusted the padding and set same width and height for all icons
- Updated chat notification count style
- ...

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original
<img width="340" alt="Screenshot 2021-12-28 at 4 02 16 PM" src="https://user-images.githubusercontent.com/13586565/147558082-cc32d057-697f-406a-b806-16ccb222e54b.png">

Updated
<img width="363" alt="Screenshot 2021-12-28 at 4 02 36 PM" src="https://user-images.githubusercontent.com/13586565/147558090-69067bae-556f-4344-bb9b-ddc1dc05a32c.png">

