### PR TITLE
Tooltip username overflowing fixed

### DIFF
--- a/template/src/subComponents/TextWithTooltip.native.tsx
+++ b/template/src/subComponents/TextWithTooltip.native.tsx
@@ -39,13 +39,25 @@ const TextWithToolTip = (props: any) => {
                 </View>
             </Modal>
             <TouchableOpacity ref={ref} onPress={() => {
-                    ref?.current?.measure( (fx, fy, localWidth, localHeight, px, py) => {
-                        // console.log('Component width is: ' + width2)
-                        // console.log('Component height is: ' + height)
-                        // console.log('X offset to frame: ' + fx)
-                        // console.log('Y offset to frame: ' + fy)
-                        // console.log('X offset to page: ' + px)
-                        // console.log('Y offset to page: ' + py)
+                    ref?.current?.measure( (fx: number, fy: number, localWidth: number, localHeight: number, px: number, py: number) => {
+                        /* To display the tooltip we are setting to position and maxwidth. so it will display above and below actual name present with modal.
+                        ---------
+                        | A | B |
+                        ---------
+                        | C | D |
+                        ---------
+                        Assume we are spliting mobile/tablet screen into 4 section
+
+                        When user click any username doing below the calculation to find (left or right postion and maxwidth). 
+                        so it won't hidden and we can use the maximum area to show tooltip
+                        
+                        For ex:
+                        Case 1: If element is present in the A or C section then we will set position top and left
+                        Case 2: If element is present in the B or D section then we will set position top and right position
+
+                        Note : we are also can doing some calculation based on height so that text won't hidden in the bottom.
+                        **/
+
                         const rightPos = (globalWidth - (px + localWidth)) - 20 < 0 ? 10 : (globalWidth - (px + localWidth)) - 20
                         const leftPos = px < 0 ? 10 : px
                         if(px > globalWidth/2){

--- a/template/src/subComponents/TextWithTooltip.native.tsx
+++ b/template/src/subComponents/TextWithTooltip.native.tsx
@@ -10,15 +10,15 @@
 *********************************************
 */
 import React, {useState, useRef} from 'react';
-import {View, Text, Modal, TouchableOpacity, TouchableWithoutFeedback, StyleSheet} from 'react-native';
+import {View, Text, Modal, TouchableOpacity, TouchableWithoutFeedback, StyleSheet, useWindowDimensions} from 'react-native';
 /**
  * Component showing text with tooltip on mobile native
  */
 const TextWithToolTip = (props: any) => {
-    const [toolTipVisible, setToolTipVisible] = useState(false)
-    const [top, setTop] = useState(0)
-    const [left, setLeft] = useState(0)
-    const ref = useRef(null)
+    const {width:globalWidth, height:globalHeight} = useWindowDimensions();
+    const [toolTipVisible, setToolTipVisible] = useState(false);
+    const [position, setPosition] = useState({})
+    const ref = useRef(null);
     return(
         <View style={{flex: 1}}>
             <Modal
@@ -34,21 +34,52 @@ const TextWithToolTip = (props: any) => {
                         style={style.backDrop} 
                     />
                 </TouchableWithoutFeedback>
-                <View style={[style.textContainer, {top: top,left: left}]}>
+                <View style={[style.textContainer, position]}>
                     <Text style={style.textStyle}>{props.value}</Text>
                 </View>
             </Modal>
             <TouchableOpacity ref={ref} onPress={() => {
-                    ref?.current?.measure( (fx, fy, width, height, px, py) => {
-                        // console.log('Component width is: ' + width)
+                    ref?.current?.measure( (fx, fy, localWidth, localHeight, px, py) => {
+                        // console.log('Component width is: ' + width2)
                         // console.log('Component height is: ' + height)
                         // console.log('X offset to frame: ' + fx)
                         // console.log('Y offset to frame: ' + fy)
                         // console.log('X offset to page: ' + px)
                         // console.log('Y offset to page: ' + py)
-                        setTop(py + height)
-                        setLeft(px)
-                        setToolTipVisible(!toolTipVisible)
+                        const rightPos = (globalWidth - (px + localWidth)) - 20 < 0 ? 10 : (globalWidth - (px + localWidth)) - 20
+                        const leftPos = px < 0 ? 10 : px
+                        if(px > globalWidth/2){
+                            if(py > globalHeight/2){
+                                setPosition({
+                                    top: py - localHeight,
+                                    right: rightPos,
+                                    maxWidth: (globalWidth - rightPos) - 30,
+                                })
+                            }else{
+                                setPosition({
+                                    top: py+localHeight,
+                                    right: rightPos,
+                                    maxWidth: (globalWidth - rightPos) - 30,
+                                })
+                            }
+                        }else{
+                            if(py > globalHeight/2){
+                                setPosition({
+                                    top: py - localHeight,
+                                    left: leftPos,
+                                    maxWidth: (globalWidth - leftPos - 5),
+                                })
+                            }else{
+                                setPosition({
+                                    top: py+localHeight,
+                                    left: leftPos,
+                                    maxWidth: (globalWidth - leftPos - 5),
+                                })
+                            }
+                        }
+                        setTimeout(() =>{
+                            setToolTipVisible(!toolTipVisible)
+                        })
                     })     
                 }}>
                 <Text style={props.style} numberOfLines={1}>{props.value}</Text>
@@ -72,7 +103,7 @@ const style = StyleSheet.create({
         marginRight: 20
     },
     textStyle:{
-        backgroundColor:'white', padding: 5, margin: 5
+        backgroundColor:'white', padding: 5, margin: 5        
     }
 })
 


### PR DESCRIPTION
# Related Issue
- Tooltip to show username are overflowing
- clickup ticket - https://app.clickup.com/t/8556478/APP-790

# Propossed changes/Fix
- Did some calculation based on the position and set max width and position value to avoid overflow

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original                
![Screenshot_2022-01-03-16-47-19-75_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/13586565/148168472-f1c1849b-ebea-4836-aa05-3a52cf40ea8f.jpg)

Updated
<img width="417" alt="Screenshot 2022-01-05 at 11 32 16 AM" src="https://user-images.githubusercontent.com/13586565/148168407-a636edea-7db0-4ffb-94a8-ae7c818c527d.png">
<img width="388" alt="Screenshot 2022-01-05 at 11 32 08 AM" src="https://user-images.githubusercontent.com/13586565/148168512-21cfe7e5-915a-4aa1-9ecf-90e0296309fb.png">

