### PR TITLE
Fixed - Messaging history is not visible in Private Chat

### DIFF
--- a/template/src/components/Chat.tsx
+++ b/template/src/components/Chat.tsx
@@ -122,7 +122,9 @@ const Chat = (props: any) => {
           }>
           {pendingPrivateNotification !== 0 ? (
             <View style={style.chatNotification}>
-              {pendingPrivateNotification}
+              <Text>
+                {pendingPrivateNotification}
+              </Text>
             </View>
           ) : null}
           <Text style={!groupActive ? style.groupTextActive : style.groupText}>
@@ -205,9 +207,9 @@ const Chat = (props: any) => {
                             {(privateMessageCountMap[user.uid] || 0) -
                               (lastCheckedPrivateState[user.uid] || 0) !==
                             0 ? (
-                              <View style={style.chatNotification}>
-                                {(privateMessageCountMap[user.uid] || 0) -
-                                  (lastCheckedPrivateState[user.uid] || 0)}
+                              <View style={style.chatNotificationPrivate}>
+                                <Text>{(privateMessageCountMap[user.uid] || 0) -
+                                  (lastCheckedPrivateState[user.uid] || 0)}</Text>
                               </View>
                             ) : null}
                             <Text style={style.participantText}>
@@ -404,6 +406,20 @@ const style = StyleSheet.create({
     left: 25,
     top: -5,
   },
+  chatNotificationPrivate:{
+    width: 20,
+    height: 20,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: $config.PRIMARY_COLOR,
+    color: $config.SECONDARY_FONT_COLOR,
+    fontFamily: Platform.OS === 'ios' ? 'Helvetica' : 'sans-serif',
+    borderRadius: 10,
+    position: 'absolute',
+    right: 25,
+    top: 0,
+  }
 });
 
 export default Chat;

--- a/template/src/subComponents/ChatContainer.tsx
+++ b/template/src/subComponents/ChatContainer.tsx
@@ -93,6 +93,14 @@ const style = StyleSheet.create({
     marginTop: 2,
     alignItems: 'center',
     paddingVertical: 10,
+    ...Platform.select({
+      android:{
+        height: 40
+      },
+      ios:{
+        height: 40
+      }
+    })
   },
   backButton: {
     marginHorizontal: 10,
@@ -107,7 +115,7 @@ const style = StyleSheet.create({
   },
   backIcon: {
     width: 20,
-    height: 12,
+    height: 20,
   },
 });
 export default ChatContainer;


### PR DESCRIPTION
# Related Issue
- Messaging history is not visible in Private Chat on Android app
- clickup ticket - https://app.clickup.com/t/1xbwy0m

# Propossed changes/Fix
- couple of notification count not wrapped by text, so wrapped notification count with  text component
- There is some alignment issue with private chat window container - fixed that

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Updated 
![Simulator Screen Shot - iPhone 13 mini - 2022-01-05 at 14 46 08](https://user-images.githubusercontent.com/13586565/148192835-19ddf129-1fa0-4332-9ca9-a62a55d0f81b.png)

![Simulator Screen Shot - iPhone 13 mini - 2022-01-05 at 14 45 25](https://user-images.githubusercontent.com/13586565/148192819-c99a2319-fc89-406b-9eea-0cb841a243d5.png)


