### PR TITLE
Fixed - Private message notification count is not shown on Android app

### DIFF
--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -83,9 +83,13 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
     (acc, curItem) => {
       let individualPrivateMessageCount = privateMessageStore[curItem].reduce(
         (total, item) => {
-			//In template/src/components/RTMConfigure.tsx
-			//on messageReceived event we are passing uid as number type for android so we should not check with ===
-          return item.uid == curItem ? total + 1 : total;
+			if(Platform.OS === 'android'){
+				//In template/src/components/RTMConfigure.tsx
+				//on messageReceived event - For android platform we are passing uid as number type. so checking == for android
+				return item.uid == curItem ? total + 1 : total;
+			}else{
+				return item.uid === curItem ? total + 1 : total;				
+			}
         },
         0,
       );

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -83,7 +83,9 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
     (acc, curItem) => {
       let individualPrivateMessageCount = privateMessageStore[curItem].reduce(
         (total, item) => {
-          return item.uid === curItem ? total + 1 : total;
+			//In template/src/components/RTMConfigure.tsx
+			//on messageReceived event we are passing uid as number type for android so we should not check with ===
+          return item.uid == curItem ? total + 1 : total;
         },
         0,
       );


### PR DESCRIPTION
# Related Issue
- Private message notification count is not shown on Android app
- clickup ticket - https://app.clickup.com/t/1xbx19y

# Propossed changes/Fix
- issue with uid type comparison, fixed by not checking type

# Additional Info 
- In RTMConfigure we are passing number data-type for uid in android

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Updated
<img width="1636" alt="Screenshot 2022-01-05 at 4 06 20 PM" src="https://user-images.githubusercontent.com/13586565/148211208-a0d66f30-2bf6-493b-8ad1-17414ce2b5a7.png">

