### PR TITLE
Disabled camera switch if video is off

### DIFF
--- a/template/src/subComponents/SwitchCamera.tsx
+++ b/template/src/subComponents/SwitchCamera.tsx
@@ -9,7 +9,7 @@ function SwitchCamera() {
   const local = useContext(LocalContext);
   return (
     <BtnTemplate
-      name={local.video ? 'switchCamera' :'switchCameraDisabled'}
+      name={'switchCamera'}
       btnText={'Switch'}
       disabled={local.video ? false : true }
       style={{

--- a/template/src/subComponents/SwitchCamera.tsx
+++ b/template/src/subComponents/SwitchCamera.tsx
@@ -2,13 +2,16 @@ import React, {useContext} from 'react';
 import {StyleSheet} from 'react-native';
 import {RtcContext} from '../../agora-rn-uikit';
 import {BtnTemplate} from '../../agora-rn-uikit';
+import {LocalContext} from '../../agora-rn-uikit';
 
 function SwitchCamera() {
   const {RtcEngine} = useContext(RtcContext);
+  const local = useContext(LocalContext);
   return (
     <BtnTemplate
-      name={'switchCamera'}
+      name={local.video ? 'switchCamera' :'switchCameraDisabled'}
       btnText={'Switch'}
+      disabled={local.video ? false : true }
       style={{
         backgroundColor: $config.SECONDARY_FONT_COLOR, //'#fff',
         borderRadius: 23,


### PR DESCRIPTION
# Related Issue
- Switch icon is enabled by turning off the video on Android app
- clickup ticket -  https://app.clickup.com/t/1xby6gb

# Propossed changes/Fix
- Based on local video context (on/off) displayed (enabled/disabled) icon for camera switch

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- https://github.com/AgoraIO-Community/ReactNative-UIKit/pull/46


# Screenshots

Updated 
<img width="328" alt="Screenshot 2022-01-07 at 3 19 40 PM" src="https://user-images.githubusercontent.com/13586565/148528168-2d1b647f-e812-4f72-bf7a-e914875b4394.png">

