### PR TITLE
BUGFIX - Hangup icons/text on participants and end call is not consistence

### DIFF
--- a/template/src/components/Navbar.tsx
+++ b/template/src/components/Navbar.tsx
@@ -87,6 +87,7 @@ const Navbar = (props: any) => {
               height: 20,
               margin: 1,
             }}
+            color='#FD0845'
           />
           <Text
             style={{

--- a/template/src/subComponents/CopyJoinInfo.tsx
+++ b/template/src/subComponents/CopyJoinInfo.tsx
@@ -79,6 +79,7 @@ const ParticipantView = (props: {showText?: boolean}) => {
       onPress={() => copyToClipboard()}
       name={'clipboard'}
       btnText={props.showText ? 'Copy Meeting Invite' : ''}
+      color={$config.PRIMARY_FONT_COLOR}
     />
   );
 };

--- a/template/src/subComponents/Recording.tsx
+++ b/template/src/subComponents/Recording.tsx
@@ -103,6 +103,7 @@ const Recording = (props: any) => {
         <ImageIcon
           name={recordingActive ? 'recordingActiveIcon' : 'recordingIcon'}
           style={[style.buttonIcon]}
+          color={recordingActive ? '#FD0845': $config.PRIMARY_COLOR}
         />
       </View>
       <Text

--- a/template/src/subComponents/RemoteEndCall.tsx
+++ b/template/src/subComponents/RemoteEndCall.tsx
@@ -22,6 +22,7 @@ const RemoteEndCall = (props: {uid: number; isHost: boolean}) => {
       onPress={() => {
         sendControlMessageToUid(controlMessageEnum.kickUser, props.uid);
       }}
+      color='#FD0845'
       name={'remoteEndCall'} // earlier was endCall, added remoteEndCall
     />
   ) : (


### PR DESCRIPTION
# Related Issue
- Hangup icons/text on participants and end call is not consistence
- clickup ticket - https://app.clickup.com/t/1ykzh2b

# Proposed changes/Fix
- To fix the color : Instead comparing the icon name passed the color value from the end call on video call screen/participants panel
- Updated color for copy meeting invite button

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- https://github.com/AgoraIO-Community/ReactNative-UIKit/pull/47


# Screenshots

Original                
<img width="1791" alt="Screenshot 2022-01-17 at 4 01 17 PM" src="https://user-images.githubusercontent.com/13586565/149753336-a0c6d24c-839c-4b41-b2a3-9f27f5c501cd.png">

Updated
<img width="1791" alt="Screenshot 2022-01-17 at 3 57 31 PM" src="https://user-images.githubusercontent.com/13586565/149753388-9e5bcd83-2768-401a-9ae6-acd8bc0052e1.png">

