### PR TITLE
Bugfix/grp cht notif count

### DIFF
--- a/template/src/components/Chat.tsx
+++ b/template/src/components/Chat.tsx
@@ -50,6 +50,10 @@ const Chat = (props: any) => {
   const [groupActive, setGroupActive] = useState(true);
   const [privateActive, setPrivateActive] = useState(false);
   const [selectedUser, setSelectedUser] = useState({uid: null});
+  //initally private state should be false
+  useEffect(()=>{
+    setPrivateChatDisplayed(false)
+  },[])
   useEffect(() => {
     if (privateActive) {
       setPrivateMessageLastSeen({

--- a/template/src/components/Chat.tsx
+++ b/template/src/components/Chat.tsx
@@ -44,6 +44,7 @@ const Chat = (props: any) => {
     lastCheckedPrivateState,
     privateMessageCountMap,
     setPrivateMessageLastSeen,
+    setPrivateChatDisplayed
   } = props;
   const {primaryColor} = useContext(ColorContext);
   const [groupActive, setGroupActive] = useState(true);
@@ -61,9 +62,11 @@ const Chat = (props: any) => {
   const selectGroup = () => {
     setPrivateActive(false);
     setGroupActive(true);
+    setPrivateChatDisplayed(false)
   };
   const selectPrivate = () => {
     setGroupActive(false);
+    setPrivateChatDisplayed(true)
   };
   const selectUser = (user: any) => {
     setSelectedUser(user);

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -45,15 +45,16 @@ const useChatNotification = (
   messageStore: string | any[],
   privateMessageStore: string | any[],
   chatDisplayed: boolean,
+  isPrivateChatDisplayed: boolean
 ) => {
   // store the last checked state from the messagestore, to identify unread messages
   const [lastCheckedPublicState, setLastCheckedPublicState] = useState(0);
   const [lastCheckedPrivateState, setLastCheckedPrivateState] = useState({});
   useEffect(() => {
-    if (chatDisplayed) {
+    if (chatDisplayed && !isPrivateChatDisplayed) {
       setLastCheckedPublicState(messageStore.length);
     }
-  }, [messageStore]);
+  }, [messageStore,isPrivateChatDisplayed]);
 
   const setPrivateMessageLastSeen = ({userId, lastSeenCount}) => {
     setLastCheckedPrivateState((prevState) => {
@@ -69,7 +70,7 @@ const useChatNotification = (
   ];
 };
 
-const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
+const NotificationControl = ({children, chatDisplayed, setSidePanel, isPrivateChatDisplayed}) => {
   const {messageStore, privateMessageStore, userList, localUid, events} =
     useContext(ChatContext);
   const [
@@ -78,7 +79,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
     lastCheckedPrivateState,
     setLastCheckedPrivateState,
     setPrivateMessageLastSeen,
-  ] = useChatNotification(messageStore, privateMessageStore, chatDisplayed);
+  ] = useChatNotification(messageStore, privateMessageStore, chatDisplayed, isPrivateChatDisplayed);
 
   const pendingPublicNotification =
     messageStore.length - lastCheckedPublicState;
@@ -245,6 +246,7 @@ const VideoCall: React.FC = () => {
   const [chatDisplayed, setChatDisplayed] = useState(false);
   const [queryComplete, setQueryComplete] = useState(false);
   const [sidePanel, setSidePanel] = useState<SidePanelType>(SidePanelType.None);
+  const [isPrivateChatDisplayed, setPrivateChatDisplayed] = useState(false)
   const {phrase} = useParams();
   const [errorMessage, setErrorMessage] = useState(null);
   const [isHost, setIsHost] = React.useState(false);
@@ -355,7 +357,9 @@ const VideoCall: React.FC = () => {
                     <View style={style.full}>
                       <NotificationControl
                         setSidePanel={setSidePanel}
-                        chatDisplayed={sidePanel === SidePanelType.Chat}>
+                        chatDisplayed={sidePanel === SidePanelType.Chat}
+                        isPrivateChatDisplayed={isPrivateChatDisplayed}
+                        >
                         {({
                           pendingPublicNotification,
                           pendingPrivateNotification,
@@ -407,6 +411,7 @@ const VideoCall: React.FC = () => {
                                 {sidePanel === SidePanelType.Chat ? (
                                   $config.CHAT ? (
                                     <Chat
+                                      setPrivateChatDisplayed={setPrivateChatDisplayed}
                                       privateMessageCountMap={
                                         privateMessageCountMap
                                       }


### PR DESCRIPTION
# Related Issue
- When private chat window is active and group notification count not showing
- clickup ticket - https://app.clickup.com/t/1xhmzn6

# Proposed changes/Fix
- Current implementation does not handle the scenario
- Added new state variable and passed set method to chat component
- From chat component updated that flag and so based on new flag it will show the group notification count

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Updated
<img width="465" alt="Screenshot 2022-01-18 at 6 06 58 PM" src="https://user-images.githubusercontent.com/13586565/149939002-8d1ba0bd-b7f5-426b-a89b-6cbb820f0506.png">

