### PR TITLE
Fixed Video icon and switch camera not showing when joining the call on native app

### DIFF
--- a/template/src/components/Precall.native.tsx
+++ b/template/src/components/Precall.native.tsx
@@ -87,11 +87,17 @@ const Precall = (props: any) => {
       <View style={{height: 20}} />
       <View style={style.controls}>
         <LocalUserContext>
-          <LocalVideoMute />
+          <View style={style.width50}>
+            <LocalVideoMute />
+          </View>
           <View style={style.width50} />
-          <LocalAudioMute />
+          <View style={style.width50}>
+            <LocalAudioMute />
+          </View>
           <View style={style.width50} />
-          <SwitchCamera />
+          <View style={style.width50}>
+            <SwitchCamera />
+          </View>
         </LocalUserContext>
       </View>
       <View
@@ -140,7 +146,12 @@ const style = StyleSheet.create({
     minHeight: 45,
     alignSelf: 'center',
   },
-  controls: {flex: 0.2, flexDirection: 'row', alignSelf: 'center', padding: 5},
+  controls: {
+    flex: 0.2,
+    flexDirection: 'row',
+    alignSelf: 'center',
+    padding: 5,
+  },
   width50: {width: 50},
   buttonActive: {
     backgroundColor: $config.PRIMARY_COLOR,


### PR DESCRIPTION
# Related Issue
- Video icon is not showing when Host/Attendee joining the call by using native app
- [clickup ticket](https://app.clickup.com/t/1xqgcyf)

# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
![image](https://user-images.githubusercontent.com/14136384/150345675-f9a7c4b6-797d-433a-b0ce-da030b80c53b.png)|![image](https://user-images.githubusercontent.com/14136384/150345704-161d5d6a-098f-469b-9596-bd6047034d0e.png)
