### PR TITLE
Private notification toast message is truncated with longer texts

### DIFF
--- a/template/react-native-toast-message/src/components/base/styles.js
+++ b/template/react-native-toast-message/src/components/base/styles.js
@@ -1,7 +1,6 @@
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 import colors from '../../colors';
 
-const deviceWidth = Dimensions.get('screen').width;
 export const HEIGHT = 60;
 
 export default StyleSheet.create({
@@ -14,8 +13,7 @@ export default StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.1,
     shadowRadius: 6,
-    elevation: 2,
-    overflow: 'hidden',
+    elevation: 2
   },
   borderLeft: {
     borderLeftWidth: 5,
@@ -47,8 +45,7 @@ export default StyleSheet.create({
   text1: {
     fontSize: 12,
     fontWeight: 'bold',
-    marginBottom: 3,
-    width: deviceWidth * 0.8
+    marginBottom: 3
   },
   text2: {
     fontSize: 10,

--- a/template/react-native-toast-message/src/components/base/styles.js
+++ b/template/react-native-toast-message/src/components/base/styles.js
@@ -1,6 +1,7 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
 import colors from '../../colors';
 
+const deviceWidth = Dimensions.get('screen').width;
 export const HEIGHT = 60;
 
 export default StyleSheet.create({
@@ -13,7 +14,8 @@ export default StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.1,
     shadowRadius: 6,
-    elevation: 2
+    elevation: 2,
+    overflow: 'hidden',
   },
   borderLeft: {
     borderLeftWidth: 5,
@@ -45,7 +47,8 @@ export default StyleSheet.create({
   text1: {
     fontSize: 12,
     fontWeight: 'bold',
-    marginBottom: 3
+    marginBottom: 3,
+    width: deviceWidth * 0.8
   },
   text2: {
     fontSize: 10,

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -116,7 +116,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
         const {uid, msg} = data;
         Toast.show({
           type: 'success',
-          text1: msg,
+          text1: msg.length > 30 ? msg.slice(0, 30) + '...' : msg,
           text2: userList[uid]?.name ? 'From: ' + userList[uid]?.name : '',
           visibilityTime: 1000,
           onPress: () => {

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -116,7 +116,7 @@ const NotificationControl = ({children, chatDisplayed, setSidePanel}) => {
         const {uid, msg} = data;
         Toast.show({
           type: 'success',
-          text1: msg.length > 50 ? msg.slice(0, 50) + '...' : msg,
+          text1: msg,
           text2: userList[uid]?.name ? 'From: ' + userList[uid]?.name : '',
           visibilityTime: 1000,
           onPress: () => {

--- a/template/src/subComponents/toastConfig.tsx
+++ b/template/src/subComponents/toastConfig.tsx
@@ -24,13 +24,14 @@ const toastConfig = {
             {...rest}
             //BaseToast is modified to have zIndex: 100
             style={{ borderLeftColor: $config.PRIMARY_COLOR, backgroundColor: $config.SECONDARY_FONT_COLOR, width: !mobileAndTabletCheck() ? '40%' : '95%'}}
-            contentContainerStyle={{ paddingHorizontal: 15 }}
+            contentContainerStyle={{ paddingHorizontal: 15, overflow: 'hidden' }}
             text1Style={{
                 fontSize: 15,
                 fontWeight: '400',
                 color: $config.PRIMARY_FONT_COLOR,
+                maxWidth: mobileAndTabletCheck() ? '70%' : '100%',
             }}
-            text1={text1}
+            text1={text1?.length > 50 ? text1.slice(0, 50) + '...' : text1}
             text2={text2}
             // text2={props.uuid}
         />

--- a/template/src/subComponents/toastConfig.tsx
+++ b/template/src/subComponents/toastConfig.tsx
@@ -24,14 +24,14 @@ const toastConfig = {
             {...rest}
             //BaseToast is modified to have zIndex: 100
             style={{ borderLeftColor: $config.PRIMARY_COLOR, backgroundColor: $config.SECONDARY_FONT_COLOR, width: !mobileAndTabletCheck() ? '40%' : '95%'}}
-            contentContainerStyle={{ paddingHorizontal: 15, overflow: 'hidden' }}
+            contentContainerStyle={{ paddingHorizontal: 15, overflow: 'hidden'}}
             text1Style={{
                 fontSize: 15,
                 fontWeight: '400',
                 color: $config.PRIMARY_FONT_COLOR,
-                maxWidth: mobileAndTabletCheck() ? '70%' : '100%',
+                width: mobileAndTabletCheck() ? '70%' : '100%',
             }}
-            text1={text1?.length > 50 ? text1.slice(0, 50) + '...' : text1}
+            text1={text1?.length > 45 ? text1.slice(0, 45) + '...' : text1}
             text2={text2}
             // text2={props.uuid}
         />

--- a/template/src/subComponents/toastConfig.tsx
+++ b/template/src/subComponents/toastConfig.tsx
@@ -28,10 +28,9 @@ const toastConfig = {
             text1Style={{
                 fontSize: 15,
                 fontWeight: '400',
-                color: $config.PRIMARY_FONT_COLOR,
-                width: mobileAndTabletCheck() ? '70%' : '100%',
+                color: $config.PRIMARY_FONT_COLOR                
             }}
-            text1={text1?.length > 45 ? text1.slice(0, 45) + '...' : text1}
+            text1={text1}
             text2={text2}
             // text2={props.uuid}
         />


### PR DESCRIPTION
# Related Issue
- Private notification toast message is truncated with longer texts
- [clickup ticket](https://app.clickup.com/t/1xbweyr)

# Propossed changes/Fix
- Applied text width based on the device width

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
*<img width="411" alt="Screenshot 2022-01-20 at 9 04 15 PM" src="https://user-images.githubusercontent.com/13586565/150370781-3de3162c-bc96-4ed7-a771-348b9f414c5d.png">* |  *<img width="415" alt="Screenshot 2022-01-20 at 9 03 30 PM" src="https://user-images.githubusercontent.com/13586565/150370823-cbb43046-1e57-400a-94d0-b1294fe132f2.png">*
