### PR TITLE
BUGFIX - Audio and video icons are not getting change when host mute the audio and turnoff the video for attendee from participant window

### DIFF
--- a/template/src/components/RTMConfigure.tsx
+++ b/template/src/components/RTMConfigure.tsx
@@ -57,7 +57,7 @@ const timeNow = () => new Date().getTime();
 const RtmConfigure = (props: any) => {
   const {setRecordingActive, callActive, name} = props;
   const {rtcProps} = useContext(PropsContext);
-  const {dispatch} = useContext(RtcContext);
+  const {RtcEngine, dispatch} = useContext(RtcContext);
   const [messageStore, setMessageStore] = useState<messageStoreInterface[]>([]);
   const [privateMessageStore, setPrivateMessageStore] = useState({});
   const [login, setLogin] = useState<boolean>(false);
@@ -276,12 +276,14 @@ const RtmConfigure = (props: any) => {
         try {
           switch (msg) {
             case controlMessageEnum.muteVideo:
+              RtcEngine.muteLocalVideoStream(true);
               dispatch({
                 type: 'LocalMuteVideo',
                 value: [0],
               });
               break;
             case controlMessageEnum.muteAudio:
+              RtcEngine.muteLocalAudioStream(true);
               dispatch({
                 type: 'LocalMuteAudio',
                 value: [0],
@@ -345,12 +347,14 @@ const RtmConfigure = (props: any) => {
           try {
             switch (msg) {
               case controlMessageEnum.muteVideo:
+                RtcEngine.muteLocalVideoStream(true);
                 dispatch({
                   type: 'LocalMuteVideo',
                   value: [0],
                 });
                 break;
               case controlMessageEnum.muteAudio:
+                RtcEngine.muteLocalAudioStream(true);
                 dispatch({
                   type: 'LocalMuteAudio',
                   value: [0],


### PR DESCRIPTION
# Related Issue
- Audio and video icons are not getting change when host mute the audio and turnoff the video for attendee from participant window
- clickup ticket - https://app.clickup.com/t/1xhh0ge

# Propossed changes/Fix
- When dispatching the mute event. callback should mute the video/audio but no call back registered for mute events
- also callback coming from propsprovider - before RTC configure. if we add RTC function into those callbacks. it was just empty object
- hence add video/audio mute function directly before dispatching

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots
N/A