### PR TITLE
Updated grid/pinned layout icon

### DIFF
--- a/template/src/components/Navbar.tsx
+++ b/template/src/components/Navbar.tsx
@@ -260,7 +260,7 @@ const Navbar = (props: any) => {
                     l === Layout.Pinned ? Layout.Grid : Layout.Pinned,
                   );
                 }}
-                name={layout ? 'gridLayoutIcon' : 'pinnedLayoutIcon'}
+                name={layout ? 'pinnedLayoutIcon' : 'gridLayoutIcon'}
               />
           </View>
           {/** Show setting icon only in non native apps


### PR DESCRIPTION
# Related Issue
- Active/inactive for chats and participants panel, layout will always be outlined.
- clickup ticket - https://app.clickup.com/t/8556478/APP-845

# Propossed changes/Fix
- Fixed chat icon highlight issue when received new message
- Updated icon for layout(grid/pinned icon)

# Additional Info 
- N/A

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A

# Screenshots

Updated
<img width="339" alt="Screenshot 2022-01-20 at 6 13 39 PM" src="https://user-images.githubusercontent.com/13586565/150351557-5dc6bd82-cb13-4429-aef6-98a819dbfd84.png">
<img width="337" alt="Screenshot 2022-01-20 at 6 13 45 PM" src="https://user-images.githubusercontent.com/13586565/150351566-42a967ff-2ef5-4a7c-949b-d619e4b3b65b.png">

