### PR TITLE
Added magic variables for log_enabled and geo_fencing

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,5 +28,7 @@
   "APPLE_CLIENT_ID": "",
   "PROFILE": "480p_8",
   "EVENT_MODE": false,
-  "RAISE_HAND": false
+  "RAISE_HAND": false,
+  "LOG_ENABLED": true,
+  "GEO_FENCING": true
 }

--- a/template/bridge/rtc/webNg/RtcEngine.ts
+++ b/template/bridge/rtc/webNg/RtcEngine.ts
@@ -30,7 +30,7 @@ import type {
 import {VideoProfile} from '../quality';
 import {ChannelProfile, ClientRole} from '../../../agora-rn-uikit';
 import {role, mode} from './Types';
-
+import {LOG_ENABLED, GEO_FENCING} from '../../../config.json';
 interface MediaDeviceInfo {
   readonly deviceId: string;
   readonly label: string;
@@ -135,10 +135,19 @@ interface RemoteStream {
   audio?: IRemoteAudioTrack;
   video?: IRemoteVideoTrack;
 }
-AgoraRTC.setArea({
-  areaCode: AREAS.GLOBAL,
-  excludedArea: AREAS.CHINA,
-});
+if (GEO_FENCING) {
+  AgoraRTC.setArea({
+    areaCode: AREAS.GLOBAL,
+    excludedArea: AREAS.CHINA,
+  });
+}
+
+if (LOG_ENABLED) {
+  AgoraRTC.setLogLevel(0);
+  AgoraRTC.enableLogUpload();
+} else {
+  AgoraRTC.disableLogUpload();
+}
 
 export default class RtcEngine {
   public appId: string;

--- a/template/global.d.ts
+++ b/template/global.d.ts
@@ -73,5 +73,7 @@ interface ConfigInterface {
   APPLE_CLIENT_ID: string;
   EVENT_MODE: boolean;
   RAISE_HAND: boolean;
+  GEO_FENCING: boolean;
+  LOG_ENABLED: boolean;
 }
 declare var $config: ConfigInterface;

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -280,6 +280,7 @@ const VideoCall: React.FC = () => {
       ? {key: null, mode: RnEncryptionEnum.AES128XTS, screenKey: null}
       : false,
     role: ClientRole.Broadcaster,
+    geoFencing: $config.GEO_FENCING,
   });
 
   const {data, loading, error} = useQuery(
@@ -325,6 +326,7 @@ const VideoCall: React.FC = () => {
         role: data.joinChannel.isHost
           ? ClientRole.Broadcaster
           : ClientRole.Audience,
+        geoFencing: $config.GEO_FENCING,
       });
       setIsHost(data.joinChannel.isHost);
       setTitle(data.joinChannel.title);


### PR DESCRIPTION
# Related Issue
  Add a magic variable for log upload and hidden magic variable
click-up ticket
https://app.clickup.com/t/1v1djur
https://app.clickup.com/t/1tjwczh

# Propossed changes/Fix
- Added GEO_FENCING and LOG_ENABLED variable
- Added conditions for geofencing and enabled the log
- Passed the flag into RTC props for RN UIKIT

# Additional Info 
- N/A

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [ ] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- https://github.com/AgoraIO-Community/ReactNative-UIKit/pull/60
- https://github.com/AgoraIO-Community/app-builder-console/pull/56


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
**original screenshot** |  **updated screenshot**
