### PR TITLE
release/rtc-sdk-ng-4.11.1

### DIFF
--- a/template/bridge/rtc/webNg/RtcEngine.ts
+++ b/template/bridge/rtc/webNg/RtcEngine.ts
@@ -426,15 +426,18 @@ export default class RtcEngine {
         // If there no mutex lock, procure a lock
         this.muteLocalAudioMutex = true;
         didProcureMutexLock = true;
-        /** setEnabled
+        /** setMuted
          *  The SDK does NOT stop audio or video capture.
-         *   The camera light stays on for video
+         *  The camera light stays on for video
          *  It takes less time for the audio or video to resume.
          */
         await this.localStream.audio?.setMuted(muted);
         // Release the lock once done
         this.muteLocalAudioMutex = false;
         this.isAudioEnabled = !muted;
+        if (muted) {
+          this.isAudioPublished = false;
+        }
         // Unpublish only after when the user has joined the call
         if (!muted && !this.isAudioPublished && this.isJoined) {
           await this.publish();

--- a/template/bridge/rtc/webNg/RtcEngine.ts
+++ b/template/bridge/rtc/webNg/RtcEngine.ts
@@ -435,9 +435,6 @@ export default class RtcEngine {
         // Release the lock once done
         this.muteLocalAudioMutex = false;
         this.isAudioEnabled = !muted;
-        if (muted) {
-          this.isAudioPublished = false;
-        }
         // Unpublish only after when the user has joined the call
         if (!muted && !this.isAudioPublished && this.isJoined) {
           await this.publish();
@@ -539,6 +536,9 @@ export default class RtcEngine {
         if (this.isJoined) {
           // Unpublish the streams when role is changed to Audience
           await this.client.unpublish();
+          this.isAudioPublished = false;
+          this.isVideoPublished = false;
+          this.isPublished = false;
         }
         await this.client.setClientRole(role.audience, options);
         await this.screenClient.setClientRole(role.audience, options);

--- a/template/package.json
+++ b/template/package.json
@@ -48,7 +48,7 @@
     "@sentry/react-native": "2.4.3",
     "@sentry/tracing": "6.2.1",
     "agora-react-native-rtm": "1.5.0",
-    "agora-rtc-sdk-ng": "4.8.2",
+    "agora-rtc-sdk-ng": "4.11.1",
     "agora-rtm-sdk": "1.4.4",
     "electron-log": "4.3.5",
     "electron-squirrel-startup": "1.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -80,7 +80,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "0.3.3",
     "@react-native-community/eslint-config": "1.1.0",
     "@types/jest": "25.2.3",
-    "@types/react-native": "0.63.52",
+    "@types/react-native": "0.67.6",
     "@types/react-native-keep-awake": "2.0.2",
     "@types/react-router-dom": "5.1.7",
     "@types/react-router-native": "5.1.0",

--- a/template/package.json
+++ b/template/package.json
@@ -48,7 +48,7 @@
     "@sentry/react-native": "2.4.3",
     "@sentry/tracing": "6.2.1",
     "agora-react-native-rtm": "1.5.0",
-    "agora-rtc-sdk-ng": "4.11.0",
+    "agora-rtc-sdk-ng": "4.8.2",
     "agora-rtm-sdk": "1.4.4",
     "electron-log": "4.3.5",
     "electron-squirrel-startup": "1.0.0",


### PR DESCRIPTION
# Related Issue
- https://agora.clickup.com/t/8556478/APP-1207
- https://agora.clickup.com/t/8556478/APP-1266
- Current version of rtc-sdk-ng is indicating the green light even after the user has stopped video streaming during the call and also after the user hangs up the call. This issue is reproducible in safari and not on chrome.

# Propossed changes/Fix
- Upgrade `agora-rtc-sdk-ng` version to `4.11.0 to 4.11.1`

# Discussions around this sdk update
- Earlier this PR was going to downgrade `agora-rtc-sdk-ng` from 4.11.0 to 4.8.2, because of some known issues around video streams in safari.
- Going forward, this PR instead of downgrading `agora-rtc-sdk-ng` to 4.8.2, will upgrade the `agora-rtc-sdk-ng` to  4.11.1, creating a ticket for CHINA team with the known issue on this sdk, this issue will be resolved in the next release of core.