### PR TITLE
Bugfix/private chat should navigate back

### DIFF
--- a/template/src/subComponents/ChatContainer.tsx
+++ b/template/src/subComponents/ChatContainer.tsx
@@ -14,6 +14,7 @@ import {
   View,
   ScrollView,
   StyleSheet,
+  TouchableOpacity,
   Platform,
   Text,
   useWindowDimensions,
@@ -21,7 +22,7 @@ import {
 import {RFValue} from 'react-native-responsive-fontsize';
 import ChatBubble from './ChatBubble';
 import ChatContext from '../components/ChatContext';
-import {BtnTemplate} from '../../agora-rn-uikit';
+import {ImageIcon} from '../../agora-rn-uikit';
 import TextWithTooltip from './TextWithTooltip';
 
 /**
@@ -41,13 +42,11 @@ const ChatContainer = (props: any) => {
   return (
     <View style={style.containerView}>
       {privateActive && (
-        <View style={style.row}>
+        <TouchableOpacity
+          style={style.row}
+          onPress={() => setPrivateActive(false)}>
           <View style={style.backButton}>
-            <BtnTemplate
-              style={[style.backIcon]}
-              onPress={() => setPrivateActive(false)}
-              name={'backBtn'}
-            />
+            <ImageIcon style={[style.backIcon]} name={'backBtn'} />
           </View>
           <View style={{flex: 1}}>
             <TextWithTooltip
@@ -61,7 +60,7 @@ const ChatContainer = (props: any) => {
               value={selectedUsername}
             />
           </View>
-        </View>
+        </TouchableOpacity>
       )}
       <ScrollView
         ref={scrollViewRef}


### PR DESCRIPTION
# Related Issue
- Clicking on participant name should take the user back to previous window
- https://agora.clickup.com/t/8556478/APP-1223

# Proposed changes/Fix
- Add touchableOpacity on the participant name

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [ ] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.


# Screenshots
**original screenshot**
:---------------------: 

https://user-images.githubusercontent.com/22396308/166920580-f5457c88-6ac7-42dd-aaaf-028f154c3090.mov

**updated screenshot**
:-----------------------:

https://user-images.githubusercontent.com/22396308/166920607-4b0fced2-1a49-4e80-9bd6-b2d40b4f3ec2.mov

