### PR TITLE
release/agora-rtc-sdk-ng-4-11-0-issues

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -48,7 +48,7 @@
     "@sentry/react-native": "2.4.3",
     "@sentry/tracing": "6.2.1",
     "agora-react-native-rtm": "1.5.0",
-    "agora-rtc-sdk-ng": "4.6.3",
+    "agora-rtc-sdk-ng": "4.11.0",
     "agora-rtm-sdk": "1.4.4",
     "electron-log": "4.3.5",
     "electron-squirrel-startup": "1.0.0",


### PR DESCRIPTION
# Related Issue
-  Camera green light does not switch off when video stream is muted on safari

# Additional Info 
- The following issue was observed when sdk `agora-rtc-sdk-ng` was updated to `4.11.0`
- Sample web demo link  https://basic-videocall-demo-dualstream.vercel.app/
- Code repo at https://github.com/SupriyaAdep/basic-videocall-demo-dualstream

# Steps to reproduce:

**On Sample web demo** link (https://vercel.com/supriyaadep/basic-videocall-demo-dualstream)
1. Open the demo link on safari
2. Click on join button, browser will ask for permissions, grant both audio and video permissions
3. We can see the video is being streamed and green light is on.
4. Click on mute video button, video streaming stops, but the green light still appears
5. Leave the call, green light still appears
6. Closing the tab makes the green light disappears.
7. Open the demo link on chrome and repeat the same step, this issue does not occur on chrome.


**On Conferencing app**
1.  Launch safari browser
2. Visit [agora meeting page](https://app-builder-core-git-release-agora-rtc-sdk-ng-4-9b65bd-agoraio.vercel.app/create)
3. Create meeting and enter precall screen
4. Toggle the camera icon(mute/unmute), observe the camera indicator(green light) on the laptop, this green light toggles as we toggle the camera icon.  Camera green light is on when camera icon is unmuted and camera green light is off, when camera icon is muted. The camera indicator behaviour is in sync with muting/unmuting camera icon, which is the expected behaviour.
5. Enter the meeting, now we are in the conferencing screen
6. Repeat step number 4, this time however, the camera green light stays on even when the camera icon is muted. 
7. Click on the hang up icon. 
8. Even though the call is finished, camera indicator still shows green light. (Indicating the camera is still being used which is not the case)
9. Close the safari browser, now the camera indicator green light is off.

As observed from the above steps, camera indicator shows green light, even when user has stopped publishing their video stream. This happens when the user is in the conferencing screen and when they hang up the call.

# Proposed fix:

I have found the issue lies with `enableDualStream` API on web. Once this API is called/executed, muting a video after this still shows green light. 

