### PR TITLE
Adding notification after record stopped

### DIFF
--- a/template/src/subComponents/Recording.tsx
+++ b/template/src/subComponents/Recording.tsx
@@ -62,9 +62,13 @@ const Recording = (props: any) => {
      * when chat icon is toggle, as Controls component is hidden and
      * shown
      */
-    if (prevRecordingState && recordingActive) {
+    if (prevRecordingState) {
       if (prevRecordingState?.recordingActive === recordingActive) return;
-      Toast.show({text1: 'Recording Started', visibilityTime: 1000});
+      Toast.show({
+        type: 'success',
+        text1: recordingActive ? 'Recording Started' : 'Recording Stopped',
+        visibilityTime: 1000,
+      });
     }
   }, [recordingActive]);
 


### PR DESCRIPTION
# Related Issue
- When recording is stopped expecting to have flash popup notification msg like - "Recording stopped.."
- [clickup ticket](https://agora.clickup.com/t/8556478/APP-1224)

# Propossed changes/Fix
- Based on the current recording state, the toast message has been updated

# Steps to Reproduce (applicable to both Conferencing as well as Live Streaming)
- Create live streaming/Conference meeting and Join as a host from mobile native or any web browsers
- Once the meeting is started host clicks the Record option "Recording started.." flash notification comes
- Click the Recording option again and observe that Recording is stopped but no flash notification popup comes

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
**original screenshot** |  <img width="1792" alt="image" src="https://user-images.githubusercontent.com/101808039/168742488-19ce53c2-a795-46dc-a862-7d6dc0523999.png">
