### PR TITLE
agora-rtc-sdk-ng to 4.12

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -48,7 +48,7 @@
     "@sentry/react-native": "2.4.3",
     "@sentry/tracing": "6.2.1",
     "agora-react-native-rtm": "1.5.0",
-    "agora-rtc-sdk-ng": "4.8.2",
+    "agora-rtc-sdk-ng": "4.12.0",
     "agora-rtm-sdk": "1.4.4",
     "electron-log": "4.3.5",
     "electron-squirrel-startup": "1.0.0",


### PR DESCRIPTION
agora-rtc-sdk-ng updated to 4.12.0 which fixes the camera green light issue.