### PR TITLE
Fix/livestreaming builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "deps": "cd template && npm i",
     "dev-setup": "npm run uikit && npm run deps && node devSetup.js",
     "web-build": "cd template && npm run web:build && cd .. && npm run copy-vercel",
-    "copy-vercel": "cp vercel.json Builds/web",
+    "copy-vercel": "cp -r Builds/web template/dist && cp vercel.json template/dist",
     "pre-release": "cd template && cp package-lock.json _package-lock.json"
   },
   "author": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,3 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "Builds/web" }
-    }
-  ],
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
Build folder changed from template/dist to Builds/web as part of SDK changes ( #98: [5f6b089](https://github.com/AgoraIO-Community/app-builder-core/pull/98/commits/5f6b0890f9adc1c436207ddb3a7c9c4c06dbe36c) )  which breaks deployment. As an earlier fix added [vercel config file](https://github.com/AgoraIO-Community/app-builder-core/tree/4ba88fecfe38905a18c861c7ff6880a6b06c10a4) which doesn't support conditional build commands which is required by live streaming build. Now fixed with copying build files to dist folder in vercel commands.

