### PR TITLE
Update SDK build to integrate better with build service

### DIFF
--- a/template/Gulpfile.js
+++ b/template/Gulpfile.js
@@ -35,14 +35,7 @@ getBuildPath = () => {
     ? path.join(__dirname, '../Builds/android')
     : path.join(__dirname, '../Builds/.electron');
   } else {
-    const outPath = process.argv[outPathArg+1].split('/').slice(0, -1).join('/')
-    return process.env.TARGET === 'wsdk'
-    ? path.join(__dirname, outPath)
-    : process.env.TARGET === 'rsdk'
-    ? path.join(__dirname, outPath)
-    : process.env.TARGET === 'android'
-    ? path.join(__dirname, outPath)
-    : path.join(__dirname, outPath);
+    return process.argv[outPathArg+1].split('/').slice(0, -1).join('/')
   }
 }
 const BUILD_PATH = getBuildPath();
@@ -202,11 +195,18 @@ const reactSdk = {
     runCli('webpack --config ./webpack.rsdk.config.js', cb);
   },
   esbuild: (cb) => {
-    let outPathArgs = '';
+    let outPath = '';
     if (outPathArg != -1) {
       outPath = ` --outpath ${process.argv[outPathArg+1]}`
     }
-    runCli(`go build -o ../esbuild-bin/rsdk ./esbuild.rsdk.go && ../esbuild-bin/rsdk${outPathArgs}`, cb);
+    let configTransformerPath = '';
+    const configTransformerPathArg = process.argv.indexOf('--configtransformerpath')
+    if (configTransformerPathArg != -1) {
+      configTransformerPath = ` --configtransformerpath ${process.argv[configTransformerPathArg+1]}`
+    }
+    let esbuildCmd = `go build -o ../esbuild-bin/rsdk ./esbuild.rsdk.go && ../esbuild-bin/rsdk${outPath}${configTransformerPath}`
+    console.log(esbuildCmd)
+    runCli(esbuildCmd, cb);
   },
   typescript: (cb) => {
     runCli(

--- a/template/Gulpfile.js
+++ b/template/Gulpfile.js
@@ -24,7 +24,7 @@ const WebpackDevServer = require('webpack-dev-server');
 const webpackConfig = require('./webpack.renderer.config');
 const webpackRsdkConfig = require('./webpack.rsdk.config');
 
-outPathArg = process.argv.indexOf('--outpath')
+const outPathArg = process.argv.indexOf('--outpath')
 getBuildPath = () => {
   if (outPathArg == -1) {
     return process.env.TARGET === 'wsdk'
@@ -53,6 +53,11 @@ const TS_DEFS_BUILD_PATH = process.env.TARGET === 'wsdk'
 : process.env.TARGET === 'android'
 ? path.join(__dirname, '../Builds/ts-defs/android')
 : path.join(__dirname, '../Builds/ts-defs/.electron');
+
+const pkgNameArg = process.argv.indexOf('--pkgname')
+const PACKAGE_NAME = pkgNameArg == -1
+  ?  'agora-app-builder-sdk'
+  : process.argv[pkgNameArg+1]
 
 let PRODUCT_NAME;
 
@@ -94,7 +99,7 @@ const general = {
     });
 
     let newPackage = {
-      name: 'agora-app-builder-sdk',
+      name: PACKAGE_NAME,
       version,
       private,
       author,
@@ -197,7 +202,11 @@ const reactSdk = {
     runCli('webpack --config ./webpack.rsdk.config.js', cb);
   },
   esbuild: (cb) => {
-    runCli(`go build -o ../esbuild-bin/rsdk ./esbuild.rsdk.go && ../esbuild-bin/rsdk ${process.argv.slice(3).join(' ')}`, cb);
+    let outPathArgs = '';
+    if (outPathArg != -1) {
+      outPath = ` --outpath ${process.argv[outPathArg+1]}`
+    }
+    runCli(`go build -o ../esbuild-bin/rsdk ./esbuild.rsdk.go && ../esbuild-bin/rsdk${outPathArgs}`, cb);
   },
   typescript: (cb) => {
     runCli(

--- a/template/esbuild.rsdk.go
+++ b/template/esbuild.rsdk.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 	"path/filepath"
@@ -170,7 +171,7 @@ func common() api.BuildOptions {
 	return commonBuildOpts
 }
 
-func rsdk() api.BuildResult {
+func rsdk(outPath *string) api.BuildResult {
 	commonBuildOpts := common()
 	rsdkBuildOpts := api.BuildOptions{
 		// build options common to rsdk and other components
@@ -197,7 +198,7 @@ func rsdk() api.BuildResult {
 		// bundle in cjs format because this index.js is meant to be used by other host applications
 		// like webpack which runs on node
 		Format:  api.FormatCommonJS,
-		Outfile: "../Builds/react-sdk/index.js",
+		Outfile: *outPath,
 
 		// other esbuild options
 		Write:             true,
@@ -215,7 +216,9 @@ func rsdk() api.BuildResult {
 }
 
 func main() {
-	rsdkRes := rsdk()
+	outPath := flag.String("outpath", "../Builds/react-sdk/index.js", "path to write bundled js file")
+	flag.Parse()
+	rsdkRes := rsdk(outPath)
 	if len(rsdkRes.Errors) > 0 {
 		spew.Dump(rsdkRes)
 		log.Fatalln("build failed")

--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -6631,9 +6631,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12229,6 +12229,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/espree/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/esprima": {
@@ -20243,6 +20255,18 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/jsdom/node_modules/tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -26213,6 +26237,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -26770,18 +26802,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/terser-webpack-plugin/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -27325,11 +27345,17 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -28748,18 +28774,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
@@ -34323,9 +34337,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-globals": {
@@ -38670,6 +38684,14 @@
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -44861,6 +44883,12 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
         "tough-cookie": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -49666,6 +49694,13 @@
       "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
       "requires": {
         "type-fest": "^0.7.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+          "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+        }
       }
     },
     "stat-mode": {
@@ -50094,12 +50129,6 @@
         "terser": "^5.7.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -50515,9 +50544,12 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -51167,12 +51199,6 @@
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true
-        },
         "enhanced-resolve": {
           "version": "5.10.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",

--- a/template/package.json
+++ b/template/package.json
@@ -32,7 +32,9 @@
     "icons:android": "react-native set-icon --path ./build/icon.png",
     "icons:ios": "react-native set-icon --path ./build/icon.png",
     "package:mac": "npm run mac:build && electron-builder --publish=always",
-    "release": "electron-builder --mac --windows --linux --publish always --config ./electron-builder.js "
+    "release": "electron-builder --mac --windows --linux --publish always --config ./electron-builder.js ",
+    "make-rsdk-ts-defs": "cross-env TARGET=rsdk NODE_ENV=production gulp makeRsdkTsDefs",
+    "make-wsdk-ts-defs": "cross-env TARGET=wsdk NODE_ENV=production gulp makeWsdkTsDefs"
   },
   "publish": [
     {

--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,6 @@
     "web-sdk:build": "cross-env TARGET=wsdk NODE_ENV=production gulp webSdk",
     "react-sdk": "cross-env TARGET=rsdk NODE_ENV=development gulp reactSdk",
     "react-sdk:build": "cross-env TARGET=rsdk NODE_ENV=production gulp reactSdk",
-    "react-sdk-esbuild": "cross-env TARGET=rsdk NODE_ENV=production gulp reactSdkEsbuild",
     "electron:start": "cross-env NODE_ENV=development gulp electron_development",
     "electron:build": "cross-env NODE_ENV=production gulp electron_build",
     "windows": "cross-env TARGET=windows npm run electron:start",


### PR DESCRIPTION
# Related Issue
- APP-2463

# Propossed changes/Fix
- Build `.d.ts` files in a separate task and use the result in websdk and reactsdk builds
- Pass output file parameter to esbuild script for reactsdk
- Read package name from build service so that build service can track the artifact to upload to S3

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [ ] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [x] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- https://github.com/sol011/build-service
- https://github.com/AgoraIO-Community/app-builder-console-backend/tree/feature/build-services
