### PR TITLE
storing  last active input device in memory

### DIFF
--- a/template/src/components/Precall.tsx
+++ b/template/src/components/Precall.tsx
@@ -29,6 +29,8 @@ import ColorContext from './ColorContext';
 import Error from '../subComponents/Error';
 import {useWakeLock} from '../components/useWakeLock';
 import mobileAndTabletCheck from '../utils/mobileWebTest';
+import DeviceContext from '../components/DeviceContext';
+import StorageContext from '../components/StorageContext';
 
 const audio = new Audio(
   'https://dl.dropboxusercontent.com/s/1cdwpm3gca9mlo0/kick.mp3',
@@ -45,8 +47,20 @@ const JoinRoomInputView = (props: any) => {
   } = props;
 
   const {awake, request} = useWakeLock();
+  const {store, setStore} = useContext(StorageContext);
+  const {selectedCam, selectedMic, setSelectedCam, setSelectedMic} =
+    useContext(DeviceContext);
 
   const onSubmit = () => {
+    // store current active mic & cam device id and reload Input devices with these prefernces for next meeting
+    if (setStore) {
+      setStore({
+        ...store,
+        lastActiveMic: selectedMic,
+        lastActiveCam: selectedCam,
+      });
+    }
+
     setCallActive(true);
     // Play a sound to avoid autoblocking in safari
     if (Platform.OS === 'web' || mobileAndTabletCheck()) {

--- a/template/src/components/StorageContext.tsx
+++ b/template/src/components/StorageContext.tsx
@@ -16,6 +16,8 @@ import useMount from './useMount';
 interface StoreInterface {
   token: null | string;
   displayName: null | string;
+  lastActiveMic: null | string;
+  lastActiveCam: null | string;
 }
 
 interface StorageContextInterface {
@@ -26,6 +28,8 @@ interface StorageContextInterface {
 const initStoreValue: StoreInterface = {
   token: null,
   displayName: '',
+  lastActiveMic: null,
+  lastActiveCam: null,
 };
 
 const initStorageContextValue = {

--- a/template/src/pages/VideoCall.tsx
+++ b/template/src/pages/VideoCall.tsx
@@ -363,7 +363,7 @@ const VideoCall: React.FC = () => {
   React.useEffect(() => {
     // Update the username in localstorage when username changes
     if (setStore) {
-      setStore({token: store?.token || null, displayName: username});
+      setStore({...store, token: store?.token || null, displayName: username});
     }
   }, [username]);
 

--- a/template/src/subComponents/SelectDevice.tsx
+++ b/template/src/subComponents/SelectDevice.tsx
@@ -14,6 +14,7 @@ import {Picker, StyleSheet, View, Text} from 'react-native';
 import {PropsContext, ClientRole} from '../../agora-rn-uikit';
 import DeviceContext from '../components/DeviceContext';
 import ColorContext from '../components/ColorContext';
+import StorageContext from '../components/StorageContext';
 // import {dropdown} from '../../theme.json';
 /**
  * A component to diplay a dropdown and select a device.
@@ -25,9 +26,16 @@ const SelectDevice = () => {
   const {primaryColor} = useContext(ColorContext);
   const {selectedCam, setSelectedCam, selectedMic, setSelectedMic, deviceList} =
     useContext(DeviceContext);
+  const {store, setStore} = useContext(StorageContext);
   // States
   const [isPickerDisabled, setPickerDisabled] = React.useState<boolean>(false);
   const [btnTheme, setBtnTheme] = React.useState<string>(primaryColor);
+  const [micSelection, setMicSelection] = React.useState(
+    () => store?.lastActiveMic,
+  );
+  const [cameraSelection, setCameraSelection] = React.useState(
+    () => store?.lastActiveCam,
+  );
 
   React.useEffect(() => {
     if ($config.EVENT_MODE && rtcProps.role === ClientRole.Audience) {
@@ -45,9 +53,11 @@ const SelectDevice = () => {
       <View>
         <Picker
           enabled={!isPickerDisabled}
-          selectedValue={selectedCam}
+          selectedValue={cameraSelection}
           style={[{borderColor: btnTheme}, style.popupPicker]}
-          onValueChange={(itemValue) => setSelectedCam(itemValue)}>
+          onValueChange={(itemValue: string) => {
+            setCameraSelection(itemValue), setSelectedCam(itemValue);
+          }}>
           {deviceList.map((device: any) => {
             if (device.kind === 'videoinput') {
               return (
@@ -62,9 +72,11 @@ const SelectDevice = () => {
         </Picker>
         <Picker
           enabled={!isPickerDisabled}
-          selectedValue={selectedMic}
+          selectedValue={micSelection}
           style={[{borderColor: btnTheme}, style.popupPicker]}
-          onValueChange={(itemValue) => setSelectedMic(itemValue)}>
+          onValueChange={(itemValue: string) => {
+            setMicSelection(itemValue), setSelectedMic(itemValue);
+          }}>
           {deviceList.map((device: any) => {
             if (device.kind === 'audioinput') {
               return (


### PR DESCRIPTION
# Related Issue
- Storing latest used audio/video device in memory, so that for the next meeting , input device selection does not defaults to first option but to the last selected one.
- https://agora.clickup.com/t/8556478/APP-2557

# Propossed changes/Fix
- saving the current device ids (mic & cam) in-store when a user clicks on  *Join Room* button in  Precall Screen.
- Retrieving it in <SelectDevices /> and providing it as a default value to the Mic and Camera Pickers.

# Additional Info 
- Any additional info or context for the reviewer

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [x] Is any third party library, service used
- [x] Tests
- [x] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- Mention dependent PR links.


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
**original screenshot** |  **updated screenshot**
![image](https://user-images.githubusercontent.com/5452261/186090677-076d9ac6-cc9d-4d01-8071-e5e1c1bc03d9.png)  |   ![image](https://user-images.githubusercontent.com/5452261/186090351-ea090acd-85c0-4595-845f-849145ca34f4.png)



