### PR TITLE
fix/web-sdk-toast-fix

### DIFF
--- a/template/react-native-toast-message/src/index.js
+++ b/template/react-native-toast-message/src/index.js
@@ -353,14 +353,14 @@ class Toast extends Component {
 
     const translateY = animation.interpolate({
       inputRange: [0, 1, 2],
-      outputRange: [0, 1, 0]
+      outputRange
     });
 
     return [
       styles.base,
       styles[position],
       {
-        opacity: translateY
+        transform: [{ translateY }]
       }
     ];
   }
@@ -378,11 +378,7 @@ class Toast extends Component {
       <Animated.View
         testID='animatedView'
         onLayout={this.onLayout}
-        style={[
-          baseStyle,
-          style,
-          { zIndex: 100, display: this.state.isVisible || this.state.inProgress ? 'flex' : 'none' }
-        ]} //added zindex
+        style={[baseStyle, style, { zIndex: 100 }]} //added zindex
         {...this.panResponder.panHandlers}>
         {this.renderContent(this.props)}
       </Animated.View>

--- a/template/react-native-toast-message/src/index.sdk.tsx
+++ b/template/react-native-toast-message/src/index.sdk.tsx
@@ -381,7 +381,7 @@ class Toast extends Component {
         style={[
           baseStyle,
           style,
-          { zIndex: 100, display: this.state.isVisible ? 'flex' : 'none', backgroundColor:'red' }
+          { zIndex: 100, display: this.state.isVisible ? 'flex' : 'none' }
         ]} //added zindex
         {...this.panResponder.panHandlers}>
         {this.renderContent(this.props)}

--- a/template/react-native-toast-message/src/styles.sdk.ts
+++ b/template/react-native-toast-message/src/styles.sdk.ts
@@ -9,7 +9,7 @@ export default StyleSheet.create({
     right: 0
   },
   top: {
-    top: 0
+    top: 30
   },
   bottom: {
     bottom: 0


### PR DESCRIPTION
Toast notification animation was changed to a fade-in fade-out from slide-in slide-out as with the slide animation it would go offscreen above the app-builder view area however in SDK scenario it is not guaranteed that the AppBuilder occupies the entire view area hence in some cases an empty toast would be visible when inactive. 

With this fix SDK will use the fade-in fade-out while the turnkey will use the Slide-in Slide-out to prevent any future problems.