### PR TITLE
use webpack to make ts defs for rsdk

### DIFF
--- a/template/Gulpfile.js
+++ b/template/Gulpfile.js
@@ -353,7 +353,7 @@ module.exports.makeRsdkTsDefs = series (
   general.clean,
   general.createBuildDirectory,
   general.packageJson,
-  reactSdk.esbuild,
+  reactSdk.webpack,
   general.typescript,
   general.typescriptFix,
   reactSdk.typescript,


### PR DESCRIPTION
This allows us to use a docker image without golang 