### PR TITLE
screen share not coming as default in pinned view

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "vercel-build": "npm run dev-setup && cd template && npm run web:build && cd .. && npm run copy-vercel",
-    "uikit": "rm -rf template/agora-rn-uikit && git clone https://github.com/AgoraIO-Community/ReactNative-UIKit.git template/agora-rn-uikit && cd template/agora-rn-uikit && git checkout release/fpe-1.0.0",
+    "uikit": "rm -rf template/agora-rn-uikit && git clone https://github.com/AgoraIO-Community/ReactNative-UIKit.git template/agora-rn-uikit && cd template/agora-rn-uikit && git checkout fix/screenshare_pinned_view",
     "deps": "cd template && npm i",
     "dev-setup": "npm run uikit && npm run deps && node devSetup.js",
     "web-build": "cd template && npm run web:build && cd .. && npm run copy-vercel",

--- a/template/customization-api/app-state.ts
+++ b/template/customization-api/app-state.ts
@@ -2,7 +2,11 @@
  * Core contexts
  */
 import {createHook} from 'customization-implementation';
-import {RtcContext, RenderContext} from '../agora-rn-uikit';
+import {
+  RtcContext,
+  RenderContext,
+  LastJoinedUserContext,
+} from '../agora-rn-uikit';
 
 // commented for v1 release
 //import {default as DeviceContext} from '../src/components/DeviceContext';
@@ -15,6 +19,8 @@ export const useRtc = createHook(RtcContext);
  * The Render app state governs the information necessary to render each user content view displayed in the videocall screen.
  */
 export const useRender = createHook(RenderContext);
+
+export const useLastJoinedUser = createHook(LastJoinedUserContext);
 export {useLocalUserInfo} from '../src/app-state/useLocalUserInfo';
 
 // commented for v1 release

--- a/template/src/subComponents/screenshare/ScreenshareConfigure.native.tsx
+++ b/template/src/subComponents/screenshare/ScreenshareConfigure.native.tsx
@@ -20,11 +20,12 @@ import {useScreenContext} from '../../components/contexts/ScreenShareContext';
 import {useString} from '../../utils/useString';
 import events from '../../rtm-events-api';
 import {EventNames, EventActions} from '../../rtm-events';
-import {useRender, useRtc} from 'customization-api';
+import {useLastJoinedUser, useRender, useRtc} from 'customization-api';
 
 export const ScreenshareConfigure = (props: {children: React.ReactNode}) => {
   const {dispatch} = useRtc();
   const {renderList, activeUids} = useRender();
+  const {lastUserJoined: lastJoinedUser} = useLastJoinedUser();
   const {setScreenShareData, screenShareData} = useScreenContext();
   // commented for v1 release
   // const getScreenShareName = useString('screenshareUserName');
@@ -39,6 +40,19 @@ export const ScreenshareConfigure = (props: {children: React.ReactNode}) => {
   useEffect(() => {
     renderListRef.current.renderList = renderList;
   }, [renderList]);
+
+  useEffect(() => {
+    if (
+      lastJoinedUser &&
+      lastJoinedUser?.uid &&
+      lastJoinedUser?.type === 'screenshare' &&
+      activeUids &&
+      activeUids.indexOf(lastJoinedUser.uid) !== -1
+    ) {
+      //set to pinned layout
+      triggerChangeLayout(true, lastJoinedUser.uid);
+    }
+  }, [lastJoinedUser]);
 
   const triggerChangeLayout = (pinned: boolean, screenShareUid?: UidType) => {
     //screenshare is started set the layout to Pinned View
@@ -74,8 +88,6 @@ export const ScreenshareConfigure = (props: {children: React.ReactNode}) => {
               },
             };
           });
-          //if remote user started/stopped the screenshare then change the layout to pinned/grid
-          triggerChangeLayout(true, screenUidOfUser);
           break;
         case EventActions.SCREENSHARE_STOPPED:
           setScreenShareData((prevState) => {


### PR DESCRIPTION
# Related Issue
- Mention your issue description here
- https://app.clickup.com/t/31a1nmq

# Propossed changes/Fix
- Created the last user joined context in RTC(In UIKIT). and CORE listened for context data and then swap the video and set pinned layout

# Additional Info 
- N/A

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [ ] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- https://github.com/AgoraIO-Community/VideoUIKit-ReactNative/pull/99


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
**original screenshot** |  **updated screenshot**
