### PR TITLE
refresh device list when labels are empty

### DIFF
--- a/template/src/components/DeviceConfigure.tsx
+++ b/template/src/components/DeviceConfigure.tsx
@@ -147,7 +147,11 @@ const DeviceConfigure: React.FC<Props> = (props: any) => {
 
   useEffect(() => {
     // If stream exists and deviceList are empty, check for devices again
-    if (deviceList.length === 0) {
+    // Labels are empty in firefox when permission is grante first time, refresh device list if labels are empty
+    if (
+      deviceList.length === 0 ||
+      deviceList.find((device: MediaDeviceInfo) => device.label === '')
+    ) {
       refreshDevices();
     }
   }, [rtc]);


### PR DESCRIPTION
# Related Issue
Labels are empty in device dropdown in firefox
![firefox-device-list-empty](https://user-images.githubusercontent.com/22396308/210517609-fadd5364-7ee1-49cd-be4e-4d12879f28ba.png)
