### PR TITLE
Fixed endcall button not clickable in minimized window

### DIFF
--- a/template/src/components/Controls.tsx
+++ b/template/src/components/Controls.tsx
@@ -423,6 +423,7 @@ const style = StyleSheet.create({
     alignItems: 'center',
   },
   centerContent: {
+    zIndex: 2,
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',


### PR DESCRIPTION
# Related Issue
- Mention your issue description here
- clickup ticket - https://app.clickup.com/t/8556478/APP-5085

# Propossed changes/Fix
- Change 1
- Change 2
- ...

# Additional Info 
- Any additional info or context for the reviewer

# Checklist
- [ ] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [ ] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- Mention dependent PR links.


# Screenshots

Original                |          Updated
:---------------------:  | :-----------------------:
**original screenshot** |  **updated screenshot**
