### PR TITLE
Remove timer when bot executes stopRecordingAPI instead call stopRecordingAPI when no one is in call

### DIFF
--- a/template/src/AppRoutes.tsx
+++ b/template/src/AppRoutes.tsx
@@ -26,14 +26,14 @@ import {LogSource, logger} from './logger/AppBuilderLogger';
 import {isValidReactComponent} from './utils/common';
 
 function VideoCallWrapper(props) {
-  const {isRecordingBotRoute} = useIsRecordingBot();
+  const {isRecordingBot} = useIsRecordingBot();
   logger.debug(
     LogSource.Internals,
     'RECORDING',
     'Check if this is a recording bot route',
-    isRecordingBotRoute,
+    isRecordingBot,
   );
-  return isRecordingBotRoute ? (
+  return isRecordingBot ? (
     <RecordingBotRoute history={props.history}>
       <VideoCall />
     </RecordingBotRoute>

--- a/template/src/subComponents/recording/useIsRecordingBot.tsx
+++ b/template/src/subComponents/recording/useIsRecordingBot.tsx
@@ -1,4 +1,6 @@
+import {useEffect} from 'react';
 import {useSearchParams} from '../../utils/useSearchParams';
+import {logger, LogSource} from '../../logger/AppBuilderLogger';
 
 interface RecordingBotUIConfig {
   chat: boolean;
@@ -10,12 +12,28 @@ interface RecordingBotUIConfig {
 const regexPattern = new RegExp('true');
 
 export function useIsRecordingBot() {
-  // Reading and setting URL params
+  /**
+   * Reading and setting URL params.
+   * To identify its a recording bot user
+   * 1. Check if bot param is there
+   * 2. Check if token param is there
+   * 3. Decode that token and check if user_id contains ******
+   */
+
   const botParam = useSearchParams().get('bot');
-  const isRecordingBot = botParam ? regexPattern.test(botParam) : false;
+  const recordingBotParam = botParam ? regexPattern.test(botParam) : false;
   const recordingBotToken = useSearchParams().get('token');
   const recordingBotName = useSearchParams().get('user_name');
-  const isRecordingBotRoute = isRecordingBot && recordingBotToken;
+  const isRecordingBot = recordingBotParam && recordingBotToken;
+
+  useEffect(() => {
+    logger.log(LogSource.Internals, 'RECORDING', 'Recording bot check', {
+      bot: recordingBotParam,
+      token: recordingBotToken,
+      name: recordingBotName,
+      isRecordingBot: isRecordingBot,
+    });
+  }, [isRecordingBot, recordingBotName, recordingBotToken, recordingBotParam]);
 
   const chatParam = useSearchParams().get('chat');
   const topBarParam = useSearchParams().get('topBar');
@@ -30,7 +48,6 @@ export function useIsRecordingBot() {
   };
 
   return {
-    isRecordingBotRoute,
     isRecordingBot,
     recordingBotToken,
     recordingBotName,

--- a/template/src/subComponents/recording/useRecording.tsx
+++ b/template/src/subComponents/recording/useRecording.tsx
@@ -672,6 +672,8 @@ const RecordingProvider = (props: RecordingProviderProps) => {
     log(
       'Recording-bot: Checking if bot should stop recording',
       !areUsersInChannel,
+      hostUids,
+      audienceUids,
     );
     if (!areUsersInChannel) {
       logger.log(

--- a/template/src/subComponents/recording/useRecording.tsx
+++ b/template/src/subComponents/recording/useRecording.tsx
@@ -174,7 +174,7 @@ const RecordingProvider = (props: RecordingProviderProps) => {
   const {setIsCaptionON} = useCaption();
   const {executePresenterQuery, executeNormalQuery} = useRecordingLayoutQuery();
   const {screenShareData} = useScreenContext();
-  const validUserCount = useRef<boolean>(false);
+  const userCountGotValidEntry = useRef<boolean>(false);
   const {isRecordingBot, recordingBotUIConfig} = useIsRecordingBot();
 
   useEffect(() => {
@@ -681,8 +681,8 @@ const RecordingProvider = (props: RecordingProviderProps) => {
        * If there are users in the call, set the user count as valid and
        * then going forward we can track if the users in the channel are reducing to zero
        */
-      if (!validUserCount.current) {
-        validUserCount.current = true;
+      if (!userCountGotValidEntry.current) {
+        userCountGotValidEntry.current = true;
       }
     }
     const shouldStopRecording = () => !areUsersInChannel && validUserCount;
@@ -690,7 +690,7 @@ const RecordingProvider = (props: RecordingProviderProps) => {
       'Recording-bot: Checking if bot should stop recording',
       shouldStopRecording(),
     );
-    if (validUserCount && !areUsersInChannel) {
+    if (userCountGotValidEntry && !areUsersInChannel) {
       logger.log(
         LogSource.Internals,
         'RECORDING',

--- a/template/src/subComponents/recording/useRecording.tsx
+++ b/template/src/subComponents/recording/useRecording.tsx
@@ -679,7 +679,8 @@ const RecordingProvider = (props: RecordingProviderProps) => {
         userCountGotValidEntry.current = true;
       }
     }
-    const shouldStopRecording = !areUsersInChannel && userCountGotValidEntry;
+    const shouldStopRecording =
+      !areUsersInChannel && userCountGotValidEntry?.current;
     log(
       'Recording-bot: Checking if bot should stop recording',
       shouldStopRecording,

--- a/template/src/subComponents/recording/useRecording.tsx
+++ b/template/src/subComponents/recording/useRecording.tsx
@@ -661,12 +661,6 @@ const RecordingProvider = (props: RecordingProviderProps) => {
      * If all the members have left the call and recording is still active -
      * bot will call the stop recording API
      */
-    log(
-      'Recording-bot: supriya user ids',
-      hostUids,
-      audienceUids,
-      hasUserJoinedRTM,
-    );
     if (!isRecordingBot) {
       return;
     }
@@ -685,12 +679,12 @@ const RecordingProvider = (props: RecordingProviderProps) => {
         userCountGotValidEntry.current = true;
       }
     }
-    const shouldStopRecording = () => !areUsersInChannel && validUserCount;
+    const shouldStopRecording = !areUsersInChannel && userCountGotValidEntry;
     log(
       'Recording-bot: Checking if bot should stop recording',
-      shouldStopRecording(),
+      shouldStopRecording,
     );
-    if (userCountGotValidEntry && !areUsersInChannel) {
+    if (shouldStopRecording) {
       logger.log(
         LogSource.Internals,
         'RECORDING',

--- a/template/src/utils/useJoinRoom.ts
+++ b/template/src/utils/useJoinRoom.ts
@@ -146,7 +146,7 @@ export default function useJoinRoom() {
             `API to ${
               isWaitingRoomEnabled ? 'channel_join_request' : 'joinChannel'
             } successful.`,
-            phrase,
+            {phrase, data},
           );
           let roomInfo: Partial<RoomInfoContextInterface['data']> = {};
 


### PR DESCRIPTION
Remove the timer of 15 seconds and instead if all users have left the call, call stop recording API